### PR TITLE
"Splash" Screen

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -7,7 +7,7 @@
   <component name="PDMPlugin">
     <option name="skipTestSources" value="false" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="21" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" project-jdk-name="21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/guis/AssessmentPanel.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/guis/AssessmentPanel.java
@@ -40,6 +40,7 @@ import edu.kit.kastel.sdq.artemis4j.grading.penalty.ThresholdPenaltyRule;
 import edu.kit.kastel.sdq.intelligrade.extensions.settings.ArtemisSettingsState;
 import edu.kit.kastel.sdq.intelligrade.state.ActiveAssessment;
 import edu.kit.kastel.sdq.intelligrade.state.PluginState;
+import edu.kit.kastel.sdq.intelligrade.utils.IntellijUtil;
 import net.miginfocom.swing.MigLayout;
 
 public class AssessmentPanel extends SimpleToolWindowPanel {
@@ -217,9 +218,9 @@ public class AssessmentPanel extends SimpleToolWindowPanel {
             return """
                     <html> <h2><span style="color: %s">%.1f</span> <span style="color: %s">%.1f</span> = %.1f of %.1f</h2></html>"""
                     .formatted(
-                            colorToCSS(JBColor.GREEN),
+                            IntellijUtil.colorToCSS(JBColor.GREEN),
                             testPoints,
-                            colorToCSS(JBColor.GREEN),
+                            IntellijUtil.colorToCSS(JBColor.GREEN),
                             Math.abs(annotationPoints),
                             totalPoints,
                             maxPoints);
@@ -227,17 +228,13 @@ public class AssessmentPanel extends SimpleToolWindowPanel {
             return """
                     <html> <h2><span style="color: %s">%.1f</span> <span style="color: %s">- %.1f</span> = %.1f of %.1f</h2></html>"""
                     .formatted(
-                            colorToCSS(JBColor.GREEN),
+                            IntellijUtil.colorToCSS(JBColor.GREEN),
                             testPoints,
-                            colorToCSS(JBColor.RED),
+                            IntellijUtil.colorToCSS(JBColor.RED),
                             Math.abs(annotationPoints),
                             totalPoints,
                             maxPoints);
         }
-    }
-
-    private static String colorToCSS(JBColor color) {
-        return "rgb(%d, %d, %d)".formatted(color.getRed(), color.getGreen(), color.getBlue());
     }
 
     private static class MistakeTypeIconRenderer {

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/guis/SplashDialog.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/guis/SplashDialog.java
@@ -1,36 +1,52 @@
+/* Licensed under EPL-2.0 2024. */
 package edu.kit.kastel.sdq.intelligrade.extensions.guis;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.TemporalAmount;
+import java.util.List;
+
+import javax.swing.Action;
+import javax.swing.JComponent;
+import javax.swing.JSeparator;
+
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.DialogWrapper;
 import com.intellij.ui.JBColor;
 import com.intellij.ui.components.JBLabel;
 import com.intellij.ui.components.JBPanel;
 import com.intellij.util.ui.JBFont;
+import edu.kit.kastel.sdq.intelligrade.utils.IntellijUtil;
 import net.miginfocom.swing.MigLayout;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import javax.swing.Action;
-import javax.swing.JComponent;
-import javax.swing.JSeparator;
-import java.util.List;
-
 public class SplashDialog extends DialogWrapper {
+    private static final TemporalAmount SPLASH_INTERVAL = Duration.ofMinutes(60);
+
     private static final List<String> REMINDER_LINES = List.of(
-            "<html><span style=\"font-weight: bold\">Be fair.</span> Follow our official grading guidelines, not your own style preferences. Only deduct points if there is a matching button.</html>",
-            "<html><span style=\"font-weight: bold\">Be nice.</span> Nobody submits bad code on purpose to upset you. Also - it's okay to deduct no points :)</html>",
-            "<html><span style=\"font-weight: bold\">Ask!</span> - if you are unsure about something. Everyone is on Element. Also check out the <a href=\"https://sdq.kastel.kit.edu/programmieren/Hauptseite\">Wiki</a>.</html>"
-    );
+            "<html><span style=\"\">Be fair.</span> <span style=\"color: %s\">Follow our official grading guidelines, not your own style preferences. Only deduct points if there is a matching button.</span></html>",
+            "<html><span style=\"\">Be nice.</span> <span style=\"color: %s\">Nobody submits bad code on purpose or to upset you. Also - it's okay to deduct no points :)</span></html>",
+            "<html><span style=\"\">Ask!</span> <span style=\"color: %s\">- if you are unsure about anything. Everyone is on Element. Also check out the .</span><a href=\"https://sdq.kastel.kit.edu/programmieren/Hauptseite\">Wiki</a></html>");
 
     private static final List<String> KEYBINDING_LINES = List.of(
-            "<html>Add Annotation <span style=\"color: %s\">Alt + A</span></html>",
-            "<html>Add Custom Message <span style=\"color: %s\">Hold Ctrl</span></html>"
-    );
+            "<html>Add Annotation  <span style=\"color: %s\">Press Button or Alt + A</span></html>",
+            "<html>Add Custom Message  <span style=\"color: %s\">Hold Ctrl</span></html>");
 
-    public SplashDialog() {
+    private static Instant lastShown = Instant.EPOCH;
+
+    public static void showMaybe() {
+        if (Instant.now().isAfter(lastShown.plus(SPLASH_INTERVAL))) {
+            lastShown = Instant.now();
+            ApplicationManager.getApplication().invokeLater(() -> new SplashDialog().show());
+        }
+    }
+
+    private SplashDialog() {
         super((Project) null);
 
-        this.setTitle("Just to Remind You...");
+        this.setTitle("Before You Start");
         this.setModal(true);
         this.init();
     }
@@ -40,13 +56,15 @@ public class SplashDialog extends DialogWrapper {
         var panel = new JBPanel<>(new MigLayout("wrap 1, fill, gapy 15", "[grow]"));
 
         for (var line : REMINDER_LINES) {
-            panel.add(new JBLabel(line).withFont(splashFont()), "growx");
+            panel.add(
+                    new JBLabel(line.formatted(IntellijUtil.colorToCSS(JBColor.GRAY))).withFont(splashFont()), "growx");
         }
 
         panel.add(new JSeparator(), "growx");
 
         for (var line : KEYBINDING_LINES) {
-            panel.add(new JBLabel(line.formatted(colorToCSS(JBColor.GRAY))).withFont(splashFont()), "growx");
+            panel.add(
+                    new JBLabel(line.formatted(IntellijUtil.colorToCSS(JBColor.GRAY))).withFont(splashFont()), "growx");
         }
 
         return panel;
@@ -54,11 +72,7 @@ public class SplashDialog extends DialogWrapper {
 
     @Override
     protected Action @NotNull [] createActions() {
-        return new Action[]{this.myOKAction};
-    }
-
-    private static String colorToCSS(JBColor color) {
-        return "rgb(%d, %d, %d)".formatted(color.getRed(), color.getGreen(), color.getBlue());
+        return new Action[] {this.myOKAction};
     }
 
     private static JBFont splashFont() {

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/guis/SplashDialog.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/guis/SplashDialog.java
@@ -10,12 +10,14 @@ import javax.swing.Action;
 import javax.swing.JComponent;
 import javax.swing.JSeparator;
 
+import com.intellij.ide.BrowserUtil;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.DialogWrapper;
 import com.intellij.ui.JBColor;
-import com.intellij.ui.components.JBLabel;
 import com.intellij.ui.components.JBPanel;
+import com.intellij.ui.dsl.builder.components.DslLabel;
+import com.intellij.ui.dsl.builder.components.DslLabelType;
 import com.intellij.util.ui.JBFont;
 import edu.kit.kastel.sdq.intelligrade.utils.IntellijUtil;
 import net.miginfocom.swing.MigLayout;
@@ -26,13 +28,13 @@ public class SplashDialog extends DialogWrapper {
     private static final TemporalAmount SPLASH_INTERVAL = Duration.ofMinutes(60);
 
     private static final List<String> REMINDER_LINES = List.of(
-            "<html><span style=\"\">Be fair.</span> <span style=\"color: %s\">Follow our official grading guidelines, not your own style preferences. Only deduct points if there is a matching button.</span></html>",
-            "<html><span style=\"\">Be nice.</span> <span style=\"color: %s\">Nobody submits bad code on purpose or to upset you. Also - it's okay to deduct no points :)</span></html>",
-            "<html><span style=\"\">Ask!</span> <span style=\"color: %s\">- if you are unsure about anything. Everyone is on Element. Also check out the .</span><a href=\"https://sdq.kastel.kit.edu/programmieren/Hauptseite\">Wiki</a></html>");
+            "<span style=\"\">Be fair.</span> <span style=\"color: %s\">Follow our official grading guidelines, not your own style preferences. Only deduct points if there is a matching button.</span>",
+            "<span style=\"\">Be nice.</span> <span style=\"color: %s\">Nobody submits bad code on purpose or to upset you. Also - it's okay to deduct no points :)</span>",
+            "<span style=\"\">Ask!</span> <span style=\"color: %1$s\">- if you are unsure about anything. Everyone is on Element. Also check out the </span><a href=\"https://sdq.kastel.kit.edu/programmieren/Hauptseite\">Wiki</a><span style=\"color: %1$s\">.</span>");
 
     private static final List<String> KEYBINDING_LINES = List.of(
-            "<html>Add Annotation  <span style=\"color: %s\">Press Button or Alt + A</span></html>",
-            "<html>Add Custom Message  <span style=\"color: %s\">Hold Ctrl</span></html>");
+            "Add Annotation  <span style=\"color: %s\">Press Button or Alt + A</span>",
+            "Add Custom Message  <span style=\"color: %s\">Hold Ctrl</span>");
 
     private static Instant lastShown = Instant.EPOCH;
 
@@ -56,15 +58,13 @@ public class SplashDialog extends DialogWrapper {
         var panel = new JBPanel<>(new MigLayout("wrap 1, fill, gapy 15", "[grow]"));
 
         for (var line : REMINDER_LINES) {
-            panel.add(
-                    new JBLabel(line.formatted(IntellijUtil.colorToCSS(JBColor.GRAY))).withFont(splashFont()), "growx");
+            panel.add(createHtmlLabel(line.formatted(IntellijUtil.colorToCSS(JBColor.GRAY))), "growx");
         }
 
         panel.add(new JSeparator(), "growx");
 
         for (var line : KEYBINDING_LINES) {
-            panel.add(
-                    new JBLabel(line.formatted(IntellijUtil.colorToCSS(JBColor.GRAY))).withFont(splashFont()), "growx");
+            panel.add(createHtmlLabel(line.formatted(IntellijUtil.colorToCSS(JBColor.GRAY))), "growx");
         }
 
         return panel;
@@ -75,7 +75,13 @@ public class SplashDialog extends DialogWrapper {
         return new Action[] {this.myOKAction};
     }
 
-    private static JBFont splashFont() {
-        return JBFont.regular().biggerOn(2.0f);
+    @SuppressWarnings("UnstableApiUsage")
+    private static JComponent createHtmlLabel(String content) {
+        // Using DslLabel since it has proper HTML link support
+        var label = new DslLabel(DslLabelType.LABEL);
+        label.setFont(JBFont.regular().biggerOn(2.0f));
+        label.setText(content);
+        label.setAction(e -> BrowserUtil.browse(e.getURL()));
+        return label;
     }
 }

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/guis/SplashDialog.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/guis/SplashDialog.java
@@ -1,0 +1,67 @@
+package edu.kit.kastel.sdq.intelligrade.extensions.guis;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.DialogWrapper;
+import com.intellij.ui.JBColor;
+import com.intellij.ui.components.JBLabel;
+import com.intellij.ui.components.JBPanel;
+import com.intellij.util.ui.JBFont;
+import net.miginfocom.swing.MigLayout;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.Action;
+import javax.swing.JComponent;
+import javax.swing.JSeparator;
+import java.util.List;
+
+public class SplashDialog extends DialogWrapper {
+    private static final List<String> REMINDER_LINES = List.of(
+            "<html><span style=\"font-weight: bold\">Be fair.</span> Follow our official grading guidelines, not your own style preferences. Only deduct points if there is a matching button.</html>",
+            "<html><span style=\"font-weight: bold\">Be nice.</span> Nobody submits bad code on purpose to upset you. Also - it's okay to deduct no points :)</html>",
+            "<html><span style=\"font-weight: bold\">Ask!</span> - if you are unsure about something. Everyone is on Element. Also check out the <a href=\"https://sdq.kastel.kit.edu/programmieren/Hauptseite\">Wiki</a>.</html>"
+    );
+
+    private static final List<String> KEYBINDING_LINES = List.of(
+            "<html>Add Annotation <span style=\"color: %s\">Alt + A</span></html>",
+            "<html>Add Custom Message <span style=\"color: %s\">Hold Ctrl</span></html>"
+    );
+
+    public SplashDialog() {
+        super((Project) null);
+
+        this.setTitle("Just to Remind You...");
+        this.setModal(true);
+        this.init();
+    }
+
+    @Override
+    protected @Nullable JComponent createCenterPanel() {
+        var panel = new JBPanel<>(new MigLayout("wrap 1, fill, gapy 15", "[grow]"));
+
+        for (var line : REMINDER_LINES) {
+            panel.add(new JBLabel(line).withFont(splashFont()), "growx");
+        }
+
+        panel.add(new JSeparator(), "growx");
+
+        for (var line : KEYBINDING_LINES) {
+            panel.add(new JBLabel(line.formatted(colorToCSS(JBColor.GRAY))).withFont(splashFont()), "growx");
+        }
+
+        return panel;
+    }
+
+    @Override
+    protected Action @NotNull [] createActions() {
+        return new Action[]{this.myOKAction};
+    }
+
+    private static String colorToCSS(JBColor color) {
+        return "rgb(%d, %d, %d)".formatted(color.getRed(), color.getGreen(), color.getBlue());
+    }
+
+    private static JBFont splashFont() {
+        return JBFont.regular().biggerOn(2.0f);
+    }
+}

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/state/PluginState.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/state/PluginState.java
@@ -129,9 +129,6 @@ public class PluginState {
                     try {
                         this.verifyLogin();
                         this.notifyConnectedListeners();
-                        ApplicationManager.getApplication().invokeLater(() -> {
-                            new SplashDialog().show();
-                        });
                     } catch (ArtemisClientException e) {
                         throw new CompletionException(e);
                     }
@@ -474,6 +471,8 @@ public class PluginState {
                     if (!initializeAssessment(nextAssessment.get())) {
                         return;
                     }
+
+                    SplashDialog.showMaybe();
 
                     // Now everything is done - the submission is properly locked, and the repository is cloned
                     if (activeAssessment.getAssessment().getAnnotations().isEmpty()) {

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/state/PluginState.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/state/PluginState.java
@@ -15,8 +15,6 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
 
-import javax.swing.*;
-
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.fileEditor.FileEditorManager;
@@ -35,6 +33,7 @@ import edu.kit.kastel.sdq.artemis4j.grading.ProgrammingSubmission;
 import edu.kit.kastel.sdq.artemis4j.grading.metajson.AnnotationMappingException;
 import edu.kit.kastel.sdq.artemis4j.grading.penalty.GradingConfig;
 import edu.kit.kastel.sdq.artemis4j.grading.penalty.InvalidGradingConfigException;
+import edu.kit.kastel.sdq.intelligrade.extensions.guis.SplashDialog;
 import edu.kit.kastel.sdq.intelligrade.extensions.settings.ArtemisCredentialsProvider;
 import edu.kit.kastel.sdq.intelligrade.extensions.settings.ArtemisSettingsState;
 import edu.kit.kastel.sdq.intelligrade.login.CefUtils;
@@ -130,6 +129,9 @@ public class PluginState {
                     try {
                         this.verifyLogin();
                         this.notifyConnectedListeners();
+                        ApplicationManager.getApplication().invokeLater(() -> {
+                            new SplashDialog().show();
+                        });
                     } catch (ArtemisClientException e) {
                         throw new CompletionException(e);
                     }

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/utils/IntellijUtil.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/utils/IntellijUtil.java
@@ -12,6 +12,7 @@ import com.intellij.openapi.vcs.impl.ProjectLevelVcsManagerImpl;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.newvfs.RefreshQueue;
+import com.intellij.ui.JBColor;
 import edu.kit.kastel.sdq.artemis4j.grading.Annotation;
 import edu.kit.kastel.sdq.intelligrade.state.ActiveAssessment;
 import org.jetbrains.idea.maven.project.MavenProjectsManager;
@@ -62,5 +63,9 @@ public final class IntellijUtil {
             throw new IllegalStateException("File not found: " + path);
         }
         return file;
+    }
+
+    public static String colorToCSS(JBColor color) {
+        return "rgb(%d, %d, %d)".formatted(color.getRed(), color.getGreen(), color.getBlue());
     }
 }


### PR DESCRIPTION
As discussed at the end of the last meeting, I've added a simple confirmation dialog that is shown when starting an assessment, but at most once per hour. I've tried to condense the most important points into three short paragraphs. They are intentionally so short, so that they are (hopefully) actually read.

![image](https://github.com/user-attachments/assets/90a854b8-2126-4c16-890f-8f5f5220868f)
