### PR TITLE
Implement some quality-of-life features

### DIFF
--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/guis/AssessmentPanel.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/guis/AssessmentPanel.java
@@ -1,4 +1,4 @@
-/* Licensed under EPL-2.0 2024. */
+/* Licensed under EPL-2.0 2024-2025. */
 package edu.kit.kastel.sdq.intelligrade.extensions.guis;
 
 import java.awt.Color;
@@ -38,6 +38,7 @@ import edu.kit.kastel.sdq.artemis4j.grading.penalty.RatingGroup;
 import edu.kit.kastel.sdq.artemis4j.grading.penalty.StackingPenaltyRule;
 import edu.kit.kastel.sdq.artemis4j.grading.penalty.ThresholdPenaltyRule;
 import edu.kit.kastel.sdq.intelligrade.extensions.settings.ArtemisSettingsState;
+import edu.kit.kastel.sdq.intelligrade.extensions.settings.ThemeColor;
 import edu.kit.kastel.sdq.intelligrade.state.ActiveAssessment;
 import edu.kit.kastel.sdq.intelligrade.state.PluginState;
 import edu.kit.kastel.sdq.intelligrade.utils.IntellijUtil;
@@ -147,7 +148,7 @@ public class AssessmentPanel extends SimpleToolWindowPanel {
             var mistakeType = assessmentButton.mistakeType();
 
             StringBuilder iconText = new StringBuilder();
-            Color color;
+            ThemeColor color;
             Font font = JBFont.regular();
 
             if (mistakeType.getReporting().shouldScore()) {
@@ -187,8 +188,8 @@ public class AssessmentPanel extends SimpleToolWindowPanel {
                 color = settings.getReportingAssessmentButtonColor();
             }
 
-            assessmentButton.iconRenderer().update(iconText.toString(), color);
-            assessmentButton.button().setForeground(color);
+            assessmentButton.iconRenderer().update(iconText.toString(), color.toColor());
+            assessmentButton.button().setForeground(color.toColor());
             assessmentButton.button().setFont(font);
         }
     }

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/guis/ExercisePanel.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/guis/ExercisePanel.java
@@ -171,34 +171,27 @@ public class ExercisePanel extends SimpleToolWindowPanel {
             return;
         }
 
-        String config;
+        GradingConfig.GradingConfigDTO config;
         try {
-            config = Files.readString(configPath);
-        } catch (IOException e) {
+            config = GradingConfig.readDTOFromString(Files.readString(configPath));
+        } catch (InvalidGradingConfigException | IOException e) {
             return;
         }
 
+        // if the selected exercise is compatible with the grading config, do nothing
         int selectedIndex = exerciseSelector.getSelectedIndex();
-        if (exerciseMatchesConfig(exerciseSelector.getItemAt(selectedIndex), config)) {
+        if (config.isAllowedForExercise(
+                exerciseSelector.getItemAt(selectedIndex).getId())) {
             return;
         }
 
         // this searches for the first exercise that the grading config can be used with
         for (int i = 0; i < exerciseSelector.getItemCount(); i++) {
             ProgrammingExercise exercise = exerciseSelector.getItemAt(i);
-            if (exerciseMatchesConfig(exercise, config)) {
+            if (config.isAllowedForExercise(exercise.getId())) {
                 exerciseSelector.setSelectedIndex(i);
                 return;
             }
-        }
-    }
-
-    private static boolean exerciseMatchesConfig(ProgrammingExercise exercise, String config) {
-        try {
-            GradingConfig.readFromString(config, exercise);
-            return true;
-        } catch (InvalidGradingConfigException e) {
-            return false;
         }
     }
 

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/settings/ArtemisSettings.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/settings/ArtemisSettings.java
@@ -1,4 +1,4 @@
-/* Licensed under EPL-2.0 2024. */
+/* Licensed under EPL-2.0 2024-2025. */
 package edu.kit.kastel.sdq.intelligrade.extensions.settings;
 
 import java.util.Objects;
@@ -11,6 +11,7 @@ import com.intellij.openapi.ui.TextBrowseFolderListener;
 import com.intellij.openapi.ui.TextFieldWithBrowseButton;
 import com.intellij.openapi.util.NlsContexts;
 import com.intellij.ui.ColorPanel;
+import com.intellij.ui.JBColor;
 import com.intellij.ui.JBIntSpinner;
 import com.intellij.ui.TitledSeparator;
 import com.intellij.ui.components.JBCheckBox;
@@ -46,10 +47,48 @@ public class ArtemisSettings implements Configurable {
 
     private JBCheckBox autoOpenMainClassCheckBox;
     private JBIntSpinner columnsPerRatingGroupSpinner;
-    private ColorPanel highlighterColorChooser;
-    private ColorPanel activeAssessmentButtonColorChooser;
-    private ColorPanel finishedAssessmentButtonColorChooser;
-    private ColorPanel reportingAssessmentButtonColorChooser;
+    private ThemeColorPanel highlighterColorChooser;
+    private ThemeColorPanel activeAssessmentButtonColorChooser;
+    private ThemeColorPanel finishedAssessmentButtonColorChooser;
+    private ThemeColorPanel reportingAssessmentButtonColorChooser;
+
+    /**
+     * This class is a color picker that changes the color to select based on the current theme.
+     * <p>
+     * When the light theme is active, the bright colors can be selected and when the dark theme is active,
+     * the dark colors can be selected.
+     */
+    private static class ThemeColorPanel extends JBPanel<JBPanel<?>> {
+        private final ColorPanel brightColorChooser;
+        private final ColorPanel darkColorChooser;
+
+        public ThemeColorPanel() {
+            super(new MigLayout("wrap 1", "[grow]"));
+
+            this.brightColorChooser = new ColorPanel();
+            this.brightColorChooser.setSupportTransparency(true);
+            this.darkColorChooser = new ColorPanel();
+            this.darkColorChooser.setSupportTransparency(true);
+
+            if (JBColor.isBright()) {
+                this.add(this.brightColorChooser, "growx");
+            } else {
+                this.add(this.darkColorChooser, "growx");
+            }
+        }
+
+        public @Nullable ThemeColor getSelectedColor() {
+            if (brightColorChooser.getSelectedColor() == null || darkColorChooser.getSelectedColor() == null) {
+                return null;
+            }
+            return new ThemeColor(brightColorChooser.getSelectedColor(), darkColorChooser.getSelectedColor());
+        }
+
+        public void setSelectedColor(ThemeColor color) {
+            brightColorChooser.setSelectedColor(color.getBrightColor());
+            darkColorChooser.setSelectedColor(color.getDarkColor());
+        }
+    }
 
     /**
      * Returns the visible name of the configurable component.
@@ -169,19 +208,19 @@ public class ArtemisSettings implements Configurable {
         contentPanel.add(columnsPerRatingGroupSpinner, "growx");
 
         contentPanel.add(new JBLabel("Highlighter color:"));
-        highlighterColorChooser = new ColorPanel();
+        highlighterColorChooser = new ThemeColorPanel();
         contentPanel.add(highlighterColorChooser, "growx");
 
         contentPanel.add(new JBLabel("Scoring grading button:"));
-        activeAssessmentButtonColorChooser = new ColorPanel();
+        activeAssessmentButtonColorChooser = new ThemeColorPanel();
         contentPanel.add(activeAssessmentButtonColorChooser, "growx");
 
         contentPanel.add(new JBLabel("Scoring grading button (limit reached):"));
-        finishedAssessmentButtonColorChooser = new ColorPanel();
+        finishedAssessmentButtonColorChooser = new ThemeColorPanel();
         contentPanel.add(finishedAssessmentButtonColorChooser, "growx");
 
         contentPanel.add(new JBLabel("Reporting grading button:"));
-        reportingAssessmentButtonColorChooser = new ColorPanel();
+        reportingAssessmentButtonColorChooser = new ThemeColorPanel();
         contentPanel.add(reportingAssessmentButtonColorChooser, "growx");
 
         return contentPanel;

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/settings/ArtemisSettingsState.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/settings/ArtemisSettingsState.java
@@ -1,4 +1,4 @@
-/* Licensed under EPL-2.0 2024. */
+/* Licensed under EPL-2.0 2024-2025. */
 package edu.kit.kastel.sdq.intelligrade.extensions.settings;
 
 import java.awt.*;
@@ -8,9 +8,10 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
-import com.intellij.ui.JBColor;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.util.xmlb.XmlSerializer;
 import com.intellij.util.xmlb.XmlSerializerUtil;
+import com.intellij.util.xmlb.annotations.OptionTag;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -20,6 +21,12 @@ import org.jetbrains.annotations.Nullable;
  */
 @State(name = "edu.kit.kastel.extensions.ArtemisSettingsState", storages = @Storage("IntelliGradeSettings.xml"))
 public class ArtemisSettingsState implements PersistentStateComponent<ArtemisSettingsState.InternalState> {
+    private static final Logger LOG = Logger.getInstance(ArtemisSettingsState.class);
+
+    private static final ThemeColor OLD_ANNOTATION_COLOR =
+            new ThemeColor(new Color(155, 54, 54), new Color(155, 54, 54));
+    private static final ThemeColor DEFAULT_ANNOTATION_COLOR =
+            new ThemeColor(new Color(225, 128, 128), new Color(75, 30, 30));
     private final InternalState state = new InternalState();
 
     // Settings need to be public for IntelliJ to serialize them
@@ -37,10 +44,17 @@ public class ArtemisSettingsState implements PersistentStateComponent<ArtemisSet
 
         public Date jwtExpiry = new Date(Long.MAX_VALUE);
 
-        public int annotationColor = new JBColor(new Color(155, 54, 54), new Color(155, 54, 54)).getRGB();
-        public int activeAssessmentButtonColor = JBColor.YELLOW.getRGB();
-        public int finishedAssessmentButtonColor = JBColor.MAGENTA.getRGB();
-        public int reportingAssessmentButtonColor = JBColor.GREEN.getRGB();
+        @OptionTag(converter = ThemeColor.ThemeColorConverter.class)
+        public ThemeColor annotationColor = DEFAULT_ANNOTATION_COLOR;
+
+        @OptionTag(converter = ThemeColor.ThemeColorConverter.class)
+        public ThemeColor activeAssessmentButtonColor = ThemeColor.yellow();
+
+        @OptionTag(converter = ThemeColor.ThemeColorConverter.class)
+        public ThemeColor finishedAssessmentButtonColor = ThemeColor.magenta();
+
+        @OptionTag(converter = ThemeColor.ThemeColorConverter.class)
+        public ThemeColor reportingAssessmentButtonColor = ThemeColor.green();
     }
 
     public static ArtemisSettingsState getInstance() {
@@ -74,6 +88,20 @@ public class ArtemisSettingsState implements PersistentStateComponent<ArtemisSet
     @Override
     public void loadState(@NotNull InternalState state) {
         XmlSerializerUtil.copyBean(state, this.state);
+
+        // The annotation color type was changed from an int to a ThemeColor.
+        // The ThemeColorConverter is able to handle converting a single number to a ThemeColor,
+        // but it would not apply the new default colors.
+        //
+        // There seems to be a dedicated mechanism for migrating configs, but there is not much
+        // documentation on it. According to what is there, it should only be used when the
+        // config changes in a major way.
+        //
+        // That is why the config is migrated here.
+        if (this.state.annotationColor.equals(OLD_ANNOTATION_COLOR)) {
+            LOG.debug("Migrating old annotation color to new format");
+            this.state.annotationColor = DEFAULT_ANNOTATION_COLOR;
+        }
     }
 
     public boolean isUseTokenLogin() {
@@ -118,12 +146,12 @@ public class ArtemisSettingsState implements PersistentStateComponent<ArtemisSet
         state.columnsPerRatingGroup = columnsPerRatingGroup;
     }
 
-    public Color getAnnotationColor() {
-        return new Color(state.annotationColor);
+    public ThemeColor getAnnotationColor() {
+        return state.annotationColor;
     }
 
-    public void setAnnotationColor(Color annotationColor) {
-        state.annotationColor = annotationColor.getRGB();
+    public void setAnnotationColor(ThemeColor annotationColor) {
+        state.annotationColor = annotationColor;
     }
 
     public Date getJwtExpiry() {
@@ -166,27 +194,27 @@ public class ArtemisSettingsState implements PersistentStateComponent<ArtemisSet
         state.vcsAccessOption = vcsAccessOption;
     }
 
-    public Color getActiveAssessmentButtonColor() {
-        return new Color(state.activeAssessmentButtonColor);
+    public ThemeColor getActiveAssessmentButtonColor() {
+        return state.activeAssessmentButtonColor;
     }
 
-    public void setActiveAssessmentButtonColor(Color activeAssessmentButtonColor) {
-        state.activeAssessmentButtonColor = activeAssessmentButtonColor.getRGB();
+    public void setActiveAssessmentButtonColor(ThemeColor activeAssessmentButtonColor) {
+        state.activeAssessmentButtonColor = activeAssessmentButtonColor;
     }
 
-    public Color getFinishedAssessmentButtonColor() {
-        return new Color(state.finishedAssessmentButtonColor);
+    public ThemeColor getFinishedAssessmentButtonColor() {
+        return state.finishedAssessmentButtonColor;
     }
 
-    public void setFinishedAssessmentButtonColor(Color finishedAssessmentButtonColor) {
-        state.finishedAssessmentButtonColor = finishedAssessmentButtonColor.getRGB();
+    public void setFinishedAssessmentButtonColor(ThemeColor finishedAssessmentButtonColor) {
+        state.finishedAssessmentButtonColor = finishedAssessmentButtonColor;
     }
 
-    public Color getReportingAssessmentButtonColor() {
-        return new Color(state.reportingAssessmentButtonColor);
+    public ThemeColor getReportingAssessmentButtonColor() {
+        return state.reportingAssessmentButtonColor;
     }
 
-    public void setReportingAssessmentButtonColor(Color reportingAssessmentButtonColor) {
-        state.reportingAssessmentButtonColor = reportingAssessmentButtonColor.getRGB();
+    public void setReportingAssessmentButtonColor(ThemeColor reportingAssessmentButtonColor) {
+        state.reportingAssessmentButtonColor = reportingAssessmentButtonColor;
     }
 }

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/settings/ThemeColor.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/settings/ThemeColor.java
@@ -1,0 +1,128 @@
+/* Licensed under EPL-2.0 2025. */
+package edu.kit.kastel.sdq.intelligrade.extensions.settings;
+
+import java.awt.Color;
+import java.util.Objects;
+
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.ui.JBColor;
+import com.intellij.util.xmlb.Converter;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * This class represents a color in a format that is supported by the plugin.
+ * <p>
+ * A dedicated class is used instead of the {@link JBColor} to allow for future changes
+ * and extensions like additional color formats.
+ */
+public class ThemeColor {
+    private final Color brightColor;
+    private final Color darkColor;
+
+    public ThemeColor(Color brightColor, Color darkColor) {
+        this.brightColor = brightColor;
+        this.darkColor = darkColor;
+    }
+
+    public static ThemeColor yellow() {
+        return new ThemeColor(Color.yellow, new Color(138, 138, 0));
+    }
+
+    public static ThemeColor green() {
+        return new ThemeColor(Color.green, new Color(98, 150, 85));
+    }
+
+    public static ThemeColor magenta() {
+        return new ThemeColor(Color.magenta, new Color(151, 118, 169));
+    }
+
+    public Color getBrightColor() {
+        return brightColor;
+    }
+
+    public Color getDarkColor() {
+        return darkColor;
+    }
+
+    /**
+     * Returns the color that should be used based on the current theme.
+     *
+     * @return the color for the current theme
+     */
+    public Color toColor() {
+        // Will choose the color based on the current theme.
+        if (JBColor.isBright()) {
+            return this.brightColor;
+        } else {
+            return this.darkColor;
+        }
+    }
+
+    public JBColor toJBColor() {
+        return new JBColor(brightColor, darkColor);
+    }
+
+    @Override
+    public final boolean equals(Object object) {
+        if (!(object instanceof ThemeColor that)) return false;
+
+        return Objects.equals(brightColor, that.brightColor) && Objects.equals(darkColor, that.darkColor);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hashCode(brightColor);
+        result = 31 * result + Objects.hashCode(darkColor);
+        return result;
+    }
+
+    /**
+     * By default, the ThemeColor class can not be serialized by IntelliJ's serialization mechanism.
+     * <p>
+     * This class provides a way to serialize and deserialize ThemeColor instances.
+     */
+    public static class ThemeColorConverter extends Converter<ThemeColor> {
+        private static final Logger LOG = Logger.getInstance(ThemeColorConverter.class);
+        private static final String SERIALIZED_DELIMITER = ";";
+        private static final int REGULAR_COLOR_INDEX = 0;
+        private static final int DARK_COLOR_INDEX = 1;
+        private static final int NUMBER_OF_FIELDS = 2;
+
+        @Override
+        public ThemeColor fromString(@NotNull String value) {
+            String[] serializedValues = value.split(SERIALIZED_DELIMITER, -1);
+
+            // In previous versions colors were stored as a single int color.
+            //
+            // When an old setting is loaded, it will use the below as fallback:
+            if (serializedValues.length == 1) {
+                Color regularColor = parseColor(serializedValues[0]);
+                LOG.warn("An old color format was provided: " + regularColor);
+                return new ThemeColor(regularColor, regularColor);
+            }
+
+            if (serializedValues.length != NUMBER_OF_FIELDS) {
+                throw new IllegalArgumentException("Invalid serialized value: " + value);
+            }
+
+            Color regularColor = parseColor(serializedValues[REGULAR_COLOR_INDEX]);
+            Color darkColor = parseColor(serializedValues[DARK_COLOR_INDEX]);
+
+            return new ThemeColor(regularColor, darkColor);
+        }
+
+        private static @NotNull Color parseColor(String string) {
+            return new Color(Integer.parseInt(string), true);
+        }
+
+        @Override
+        public String toString(@NotNull ThemeColor color) {
+            String[] serializedValues = new String[NUMBER_OF_FIELDS];
+
+            serializedValues[REGULAR_COLOR_INDEX] = String.valueOf(color.brightColor.getRGB());
+            serializedValues[DARK_COLOR_INDEX] = String.valueOf(color.darkColor.getRGB());
+
+            return String.join(SERIALIZED_DELIMITER, serializedValues);
+        }
+    }
+}

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/highlighter/HighlighterManager.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/highlighter/HighlighterManager.java
@@ -130,6 +130,10 @@ public class HighlighterManager {
     private static void createHighlighter(Editor editor, int startLine, List<Annotation> annotations) {
         var document = FileDocumentManager.getInstance().getDocument(editor.getVirtualFile());
 
+        if (document == null) {
+            return;
+        }
+
         int startOffset = document.getLineStartOffset(startLine);
         int endOffset = document.getLineEndOffset(
                 annotations.stream().mapToInt(Annotation::getEndLine).max().orElse(startLine));

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/highlighter/HighlighterManager.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/highlighter/HighlighterManager.java
@@ -32,6 +32,7 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.ui.AnActionButton;
 import edu.kit.kastel.sdq.artemis4j.grading.Annotation;
+import edu.kit.kastel.sdq.artemis4j.grading.penalty.MistakeType;
 import edu.kit.kastel.sdq.intelligrade.extensions.guis.AnnotationsListPanel;
 import edu.kit.kastel.sdq.intelligrade.extensions.settings.ArtemisSettingsState;
 import edu.kit.kastel.sdq.intelligrade.icons.ArtemisIcons;
@@ -141,6 +142,15 @@ public class HighlighterManager {
         var annotationColor = ArtemisSettingsState.getInstance().getAnnotationColor();
         var attributes = new TextAttributes(
                 null, annotationColor.toJBColor(), null, EffectType.BOLD_LINE_UNDERSCORE, Font.PLAIN);
+
+        // there can be multiple annotations on the same line, if all don't have a highlight, create an invisible
+        // highlighter
+        if (annotations.stream()
+                .map(Annotation::getMistakeType)
+                .map(MistakeType::getHighlight)
+                .allMatch(highlight -> highlight == MistakeType.Highlight.NONE)) {
+            attributes = new TextAttributes();
+        }
 
         var highlighter = editor.getMarkupModel()
                 .addRangeHighlighter(

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/highlighter/HighlighterManager.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/highlighter/HighlighterManager.java
@@ -1,4 +1,4 @@
-/* Licensed under EPL-2.0 2024. */
+/* Licensed under EPL-2.0 2024-2025. */
 package edu.kit.kastel.sdq.intelligrade.highlighter;
 
 import java.awt.Font;
@@ -31,7 +31,6 @@ import com.intellij.openapi.ui.popup.JBPopup;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.ui.AnActionButton;
-import com.intellij.ui.JBColor;
 import edu.kit.kastel.sdq.artemis4j.grading.Annotation;
 import edu.kit.kastel.sdq.intelligrade.extensions.guis.AnnotationsListPanel;
 import edu.kit.kastel.sdq.intelligrade.extensions.settings.ArtemisSettingsState;
@@ -137,7 +136,7 @@ public class HighlighterManager {
 
         var annotationColor = ArtemisSettingsState.getInstance().getAnnotationColor();
         var attributes = new TextAttributes(
-                null, new JBColor(annotationColor, annotationColor), null, EffectType.BOLD_LINE_UNDERSCORE, Font.PLAIN);
+                null, annotationColor.toJBColor(), null, EffectType.BOLD_LINE_UNDERSCORE, Font.PLAIN);
 
         var highlighter = editor.getMarkupModel()
                 .addRangeHighlighter(

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/listeners/FileOpener.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/listeners/FileOpener.java
@@ -93,15 +93,11 @@ public final class FileOpener implements DumbService.DumbModeListener {
         PsiType stringType =
                 PsiType.getJavaLangString(PsiManager.getInstance(project), GlobalSearchScope.allScope(project));
         for (var method : mainMethods) {
-            // Is public & static
+            // Is public & static & returns void
             var modifiers = method.getModifierList();
             if (!modifiers.hasExplicitModifier(PsiModifier.PUBLIC)
-                    || !modifiers.hasExplicitModifier(PsiModifier.STATIC)) {
-                continue;
-            }
-
-            // Returns void
-            if (!PsiTypes.voidType().equals(method.getReturnType())) {
+                    || !modifiers.hasExplicitModifier(PsiModifier.STATIC)
+                    || !PsiTypes.voidType().equals(method.getReturnType())) {
                 continue;
             }
 

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/state/ActiveAssessment.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/state/ActiveAssessment.java
@@ -1,4 +1,4 @@
-/* Licensed under EPL-2.0 2024. */
+/* Licensed under EPL-2.0 2024-2025. */
 package edu.kit.kastel.sdq.intelligrade.state;
 
 import java.awt.EventQueue;
@@ -64,19 +64,18 @@ public class ActiveAssessment {
             throw new IllegalStateException("No active assessment");
         }
 
-        var selection = CodeSelection.fromCaret();
-        if (selection.isEmpty()) {
+        var selection = CodeSelection.fromCaret().orElse(null);
+        if (selection == null) {
             ArtemisUtils.displayGenericErrorBalloon(
                     "No code selected", "Cannot create annotation without code selection");
             return;
         }
 
-        var editor = IntellijUtil.getActiveEditor();
-        int startLine = editor.getDocument().getLineNumber(selection.get().startOffset());
-        int endLine = editor.getDocument().getLineNumber(selection.get().endOffset());
+        int startLine = selection.startLine();
+        int endLine = selection.endLine();
         String path = Path.of(IntellijUtil.getActiveProject().getBasePath())
                 .resolve(ASSIGNMENT_SUB_PATH)
-                .relativize(selection.get().path())
+                .relativize(selection.path())
                 .toString()
                 .replace("\\", "/");
 

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/state/PluginState.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/state/PluginState.java
@@ -361,6 +361,9 @@ public class PluginState {
                 IntellijUtil.getMavenManager().forceUpdateAllProjectsOrFindAllAvailablePomFiles();
             });
 
+            // Sometimes the SDK is not set properly, this will set the SDK if it is not set
+            IntellijUtil.updateProjectSDK();
+
             this.activeAssessment = new ActiveAssessment(assessment, clonedSubmission);
             for (Consumer<ActiveAssessment> listener : this.assessmentStartedListeners) {
                 listener.accept(activeAssessment);

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/state/PluginState.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/state/PluginState.java
@@ -355,6 +355,9 @@ public class PluginState {
                                 .cloneViaVCSTokenInto(IntellijUtil.getProjectRootDirectory(), null);
                     };
 
+            // TODO: might have to be spawned in a background thread
+            IntellijUtil.setupProjectProfile();
+
             // Refresh all files, so that they are up-to-date for the maven update
             IntellijUtil.forceFilesSync(() -> {
                 // Force IntelliJ to update the Maven project

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/state/PluginState.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/state/PluginState.java
@@ -1,4 +1,4 @@
-/* Licensed under EPL-2.0 2024. */
+/* Licensed under EPL-2.0 2024-2025. */
 package edu.kit.kastel.sdq.intelligrade.state;
 
 import java.io.IOException;
@@ -179,6 +179,7 @@ public class PluginState {
         try {
             activeAssessment.getAssessment().save();
             ArtemisUtils.displayGenericInfoBalloon("Assessment saved", "The assessment has been saved.");
+            this.cleanupAssessment();
         } catch (ArtemisNetworkException e) {
             LOG.warn(e);
             ArtemisUtils.displayNetworkErrorBalloon("Could not save assessment", e);

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/utils/IntellijUtil.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/utils/IntellijUtil.java
@@ -1,23 +1,37 @@
-/* Licensed under EPL-2.0 2024. */
+/* Licensed under EPL-2.0 2024-2025. */
 package edu.kit.kastel.sdq.intelligrade.utils;
 
 import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Objects;
 
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.WriteAction;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
+import com.intellij.openapi.projectRoots.ProjectJdkTable;
+import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.openapi.projectRoots.SdkTypeId;
+import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.vcs.impl.ProjectLevelVcsManagerImpl;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.newvfs.RefreshQueue;
 import com.intellij.ui.JBColor;
+import com.intellij.util.lang.JavaVersion;
 import edu.kit.kastel.sdq.artemis4j.grading.Annotation;
 import edu.kit.kastel.sdq.intelligrade.state.ActiveAssessment;
 import org.jetbrains.idea.maven.project.MavenProjectsManager;
 
 public final class IntellijUtil {
+    private static final Logger LOG = Logger.getInstance(IntellijUtil.class);
+    private static final String JAVA_SDK_TYPE_NAME = "JavaSDK";
+    private static final int TARGET_SDK_VERSION = 17;
+
     private IntellijUtil() {
         throw new IllegalStateException("Utility class");
     }
@@ -48,6 +62,56 @@ public final class IntellijUtil {
 
     public static ProjectLevelVcsManagerImpl getVcsManager() {
         return ProjectLevelVcsManagerImpl.getInstanceImpl(IntellijUtil.getActiveProject());
+    }
+
+    /**
+     * Checks if the active project has a JDK set and if not, it will set a JDK.
+     */
+    public static void updateProjectSDK() {
+        // It is amazing how much is possible, the difficult part is finding the right classes
+        // that do what you want... this was much more work than it looks like.
+        var manager = ProjectRootManager.getInstance(getActiveProject());
+
+        // check if SDK is already set
+        var projectSdk = manager.getProjectSdk();
+        if (projectSdk != null) {
+            LOG.debug("SDK already set: " + projectSdk.getVersionString());
+            return;
+        }
+
+        // if not, set the SDK.
+
+        var jdkTable = ProjectJdkTable.getInstance();
+
+        SdkTypeId javaSdkTypeId = jdkTable.getSdkTypeByName(JAVA_SDK_TYPE_NAME);
+
+        var availableSdks = ProjectJdkTable.getInstance().getSdksOfType(javaSdkTypeId);
+        if (availableSdks.isEmpty()) {
+            LOG.error("No SDK found, please install a JDK");
+            return;
+        }
+
+        // they are sorted starting from the latest version
+        List<Sdk> sortedSdks = availableSdks.stream()
+                .filter(sdk -> sdk.getVersionString() != null && JavaVersion.tryParse(sdk.getVersionString()) != null)
+                .sorted(Comparator.comparing((Sdk sdk) -> JavaVersion.parse(sdk.getVersionString())))
+                .toList();
+
+        LOG.debug("Available SDKs: " + sortedSdks);
+        for (var availableSdk : availableSdks) {
+            if (availableSdk.getVersionString() == null) {
+                continue;
+            }
+
+            if (JavaVersion.parse(availableSdk.getVersionString()).isAtLeast(TARGET_SDK_VERSION)) {
+                // update the project sdk, this has to be done in a dedicated thread to prevent crashes
+                ApplicationManager.getApplication()
+                        .invokeLater(() -> WriteAction.run(() -> manager.setProjectSdk(availableSdk)));
+                return;
+            }
+        }
+
+        LOG.error("No suitable SDK found, please install a JDK with version " + TARGET_SDK_VERSION + " or higher");
     }
 
     public static Path getAnnotationPath(Annotation annotation) {

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/utils/IntellijUtil.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/utils/IntellijUtil.java
@@ -126,8 +126,8 @@ public final class IntellijUtil {
     public static void setupProjectProfile() {
         var project = getActiveProject();
 
-        Path path = Path.of(project.getBasePath() + "/" + Project.DIRECTORY_STORE_FOLDER + "/"
-                + "inspectionProfiles/Project_Default.xml");
+        Path path = Path.of(
+                project.getBasePath(), Project.DIRECTORY_STORE_FOLDER, "inspectionProfiles", "Project_Default.xml");
 
         try {
             // create the directory if it does not exist

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/utils/IntellijUtil.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/utils/IntellijUtil.java
@@ -1,6 +1,9 @@
 /* Licensed under EPL-2.0 2024-2025. */
 package edu.kit.kastel.sdq.intelligrade.utils;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.List;
@@ -112,6 +115,28 @@ public final class IntellijUtil {
         }
 
         LOG.error("No suitable SDK found, please install a JDK with version " + TARGET_SDK_VERSION + " or higher");
+    }
+
+    private static String loadInspectionsProfile() throws IOException {
+        try (var in = IntellijUtil.class.getResourceAsStream("/Project_Default.xml")) {
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    public static void setupProjectProfile() {
+        var project = getActiveProject();
+
+        Path path = Path.of(project.getBasePath() + "/" + Project.DIRECTORY_STORE_FOLDER + "/"
+                + "inspectionProfiles/Project_Default.xml");
+
+        try {
+            // create the directory if it does not exist
+            Files.createDirectories(path.getParent());
+            // write the default profile to the file
+            Files.writeString(path, loadInspectionsProfile());
+        } catch (IOException ioException) {
+            throw new IllegalStateException("Could not write default profile", ioException);
+        }
     }
 
     public static Path getAnnotationPath(Annotation annotation) {

--- a/src/main/resources/Project_Default.xml
+++ b/src/main/resources/Project_Default.xml
@@ -1,0 +1,256 @@
+<profile version="1.0">
+  <option name="myName" value="Project Default" />
+  <inspection_tool class="AbstractClassWithoutAbstractMethods" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="ArrayCanBeReplacedWithEnumValues" enabled="true" level="WEAK WARNING" enabled_by_default="true" editorAttributes="INFO_ATTRIBUTES" />
+  <inspection_tool class="ArrayEquality" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="AssignmentOrReturnOfFieldWithMutableType" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="AssignmentToForLoopParameter" enabled="true" level="WARNING" enabled_by_default="true">
+    <option name="m_checkForeachParameters" value="true" />
+  </inspection_tool>
+  <inspection_tool class="AssignmentToLambdaParameter" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="AssignmentToMethodParameter" enabled="true" level="WARNING" enabled_by_default="true">
+    <option name="ignoreTransformationOfOriginalParameter" value="false" />
+  </inspection_tool>
+  <inspection_tool class="AssignmentToStaticFieldFromInstanceMethod" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="AssignmentToSuperclassField" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="AutoCloseableResource" enabled="true" level="WARNING" enabled_by_default="true">
+    <option name="METHOD_MATCHER_CONFIG" value="java.util.Formatter,format,java.io.Writer,append,com.google.common.base.Preconditions,checkNotNull,org.hibernate.Session,close,java.io.PrintWriter,printf,java.io.PrintStream,printf,javax.tools.SimpleJavaFileObject,openWriter" />
+  </inspection_tool>
+  <inspection_tool class="BadExceptionCaught" enabled="true" level="WARNING" enabled_by_default="true">
+    <option name="exceptionsString" value="" />
+    <option name="exceptions">
+      <value />
+    </option>
+  </inspection_tool>
+  <inspection_tool class="BadExceptionDeclared" enabled="true" level="WARNING" enabled_by_default="true">
+    <option name="exceptionsString" value="" />
+    <option name="exceptions">
+      <value />
+    </option>
+    <option name="ignoreTestCases" value="false" />
+    <option name="ignoreLibraryOverrides" value="false" />
+  </inspection_tool>
+  <inspection_tool class="BadExceptionThrown" enabled="true" level="WARNING" enabled_by_default="true">
+    <option name="exceptionsString" value="" />
+    <option name="exceptions">
+      <value />
+    </option>
+  </inspection_tool>
+  <inspection_tool class="BlockMarkerComments" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="BooleanParameter" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="BoundedWildcard" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="CallToStringConcatCanBeReplacedByOperator" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="CastCanBeReplacedWithVariable" enabled="true" level="WEAK WARNING" enabled_by_default="true" editorAttributes="INFO_ATTRIBUTES" />
+  <inspection_tool class="ChainedEquality" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="ClassMayBeInterface" enabled="true" level="WARNING" enabled_by_default="true" editorAttributes="WARNING_ATTRIBUTES" />
+  <inspection_tool class="ClassNameDiffersFromFileName" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="ClassWithOnlyPrivateConstructors" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="CollectionsFieldAccessReplaceableByMethodCall" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="ComparableImplementedButEqualsNotOverridden" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="ConditionalBreakInInfiniteLoop" enabled="true" level="WARNING" enabled_by_default="true">
+    <option name="allowConditionFusion" value="true" />
+  </inspection_tool>
+  <inspection_tool class="ConfusingElse" enabled="true" level="WEAK WARNING" enabled_by_default="true" editorAttributes="INFO_ATTRIBUTES">
+    <option name="reportWhenNoStatementFollow" value="true" />
+  </inspection_tool>
+  <inspection_tool class="ControlFlowStatementWithoutBraces" enabled="true" level="WEAK WARNING" enabled_by_default="true" editorAttributes="INFO_ATTRIBUTES" />
+  <inspection_tool class="DateToString" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="DeclareCollectionAsInterface" enabled="true" level="WARNING" enabled_by_default="true">
+    <option name="ignoreLocalVariables" value="false" />
+    <option name="ignorePrivateMethodsAndFields" value="false" />
+  </inspection_tool>
+  <inspection_tool class="DiamondCanBeReplacedWithExplicitTypeArguments" enabled="true" level="WEAK WARNING" enabled_by_default="true" editorAttributes="INFO_ATTRIBUTES" />
+  <inspection_tool class="DollarSignInName" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="DoubleBraceInitialization" enabled="true" level="WEAK WARNING" enabled_by_default="true" editorAttributes="INFO_ATTRIBUTES" />
+  <inspection_tool class="DuplicateStringLiteralInspection" enabled="true" level="WARNING" enabled_by_default="true">
+    <option name="MIN_STRING_LENGTH" value="5" />
+    <option name="IGNORE_PROPERTY_KEYS" value="false" />
+  </inspection_tool>
+  <inspection_tool class="EmptyClass" enabled="true" level="WARNING" enabled_by_default="true">
+    <option name="ignorableAnnotations">
+      <value />
+    </option>
+    <option name="ignoreClassWithParameterization" value="false" />
+    <option name="ignoreThrowables" value="true" />
+    <option name="commentsAreContent" value="true" />
+  </inspection_tool>
+  <inspection_tool class="EnumerationCanBeIteration" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="EqualsAndHashcode" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="EqualsCalledOnEnumConstant" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="ErrorRethrown" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="ExceptionNameDoesntEndWithException" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="ExpressionMayBeFactorized" enabled="true" level="WEAK WARNING" enabled_by_default="true" editorAttributes="INFO_ATTRIBUTES" />
+  <inspection_tool class="ExtendsThrowable" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="FallthruInSwitchStatement" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="FieldMayBeStatic" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="FloatingPointEquality" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="HardCodedStringLiteral" enabled="true" level="WARNING" enabled_by_default="true">
+    <option name="ignoreForAssertStatements" value="true" />
+    <option name="ignoreForExceptionConstructors" value="false" />
+    <option name="ignoreForSpecifiedExceptionConstructors" value="" />
+    <option name="ignoreForJUnitAsserts" value="true" />
+    <option name="ignoreForClassReferences" value="true" />
+    <option name="ignoreForPropertyKeyReferences" value="true" />
+    <option name="ignoreForNonAlpha" value="false" />
+    <option name="ignoreAssignedToConstants" value="true" />
+    <option name="ignoreToString" value="false" />
+    <option name="nonNlsCommentPattern" value="NON-NLS" />
+    <option name="ignoreForEnumConstant" value="true" />
+  </inspection_tool>
+  <inspection_tool class="HtmlTagCanBeJavadocTag" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="IfStatementWithIdenticalBranches" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+    <option name="myHighlightElseIf" value="true" />
+  </inspection_tool>
+  <inspection_tool class="InstanceVariableOfConcreteClass" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="InstanceofCatchParameter" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="InstanceofThis" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="IntLiteralMayBeLongLiteral" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="InterfaceMayBeAnnotatedFunctional" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="JavaLangImport" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="JoinDeclarationAndAssignmentJava" enabled="true" level="WEAK WARNING" enabled_by_default="true" editorAttributes="INFO_ATTRIBUTES" />
+  <inspection_tool class="MagicCharacter" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="MagicNumber" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="MarkerInterface" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="MethodMayBeStatic" enabled="true" level="WARNING" enabled_by_default="true">
+    <option name="m_onlyPrivateOrFinal" value="false" />
+    <option name="m_ignoreEmptyMethods" value="true" />
+  </inspection_tool>
+  <inspection_tool class="MethodOnlyUsedFromInnerClass" enabled="true" level="WARNING" enabled_by_default="true">
+    <option name="ignoreMethodsAccessedFromAnonymousClass" value="false" />
+    <option name="ignoreStaticMethodsFromNonStaticInnerClass" value="false" />
+    <option name="onlyReportStaticMethods" value="false" />
+  </inspection_tool>
+  <inspection_tool class="MissingOverrideAnnotation" enabled="true" level="WEAK WARNING" enabled_by_default="true" editorAttributes="INFO_ATTRIBUTES">
+    <option name="ignoreObjectMethods" value="false" />
+    <option name="ignoreAnonymousClassMethods" value="false" />
+  </inspection_tool>
+  <inspection_tool class="MissortedModifiers" enabled="true" level="WARNING" enabled_by_default="true">
+    <option name="m_requireAnnotationsFirst" value="true" />
+  </inspection_tool>
+  <inspection_tool class="MisspelledEquals" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="MoveFieldAssignmentToInitializer" enabled="true" level="WEAK WARNING" enabled_by_default="true" editorAttributes="INFO_ATTRIBUTES" />
+  <inspection_tool class="MultipleTopLevelClassesInFile" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="MultipleVariablesInDeclaration" enabled="true" level="WEAK WARNING" enabled_by_default="true" editorAttributes="INFO_ATTRIBUTES" />
+  <inspection_tool class="NegatedConditional" enabled="true" level="WARNING" enabled_by_default="true">
+    <option name="m_ignoreNegatedNullComparison" value="true" />
+  </inspection_tool>
+  <inspection_tool class="NegatedConditionalExpression" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="NegatedEqualityExpression" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="NegatedIfElse" enabled="true" level="WARNING" enabled_by_default="true">
+    <option name="m_ignoreNegatedNullComparison" value="true" />
+    <option name="m_ignoreNegatedZeroComparison" value="false" />
+  </inspection_tool>
+  <inspection_tool class="NestedAssignment" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="NestedConditionalExpression" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="NewExceptionWithoutArguments" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="NonExceptionNameEndsWithException" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="NonFinalFieldOfException" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="NonFinalUtilityClass" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="NonProtectedConstructorInAbstractClass" enabled="true" level="TEXT ATTRIBUTES" enabled_by_default="true" editorAttributes="NOT_USED_ELEMENT_ATTRIBUTES">
+    <option name="m_ignoreNonPublicClasses" value="false" />
+  </inspection_tool>
+  <inspection_tool class="NonShortCircuitBoolean" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="NoopMethodInAbstractClass" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="ObsoleteCollection" enabled="true" level="WARNING" enabled_by_default="true">
+    <option name="ignoreRequiredObsoleteCollectionTypes" value="true" />
+  </inspection_tool>
+  <inspection_tool class="OnDemandImport" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="OptionalContainsCollection" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="OverlyStrongTypeCast" enabled="true" level="WARNING" enabled_by_default="true">
+    <option name="ignoreInMatchingInstanceof" value="false" />
+  </inspection_tool>
+  <inspection_tool class="ProblematicWhitespace" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="PublicConstructorInNonPublicClass" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="PublicField" enabled="true" level="WARNING" enabled_by_default="true">
+    <option name="ignoreEnums" value="false" />
+    <option name="ignorableAnnotations">
+      <value />
+    </option>
+  </inspection_tool>
+  <inspection_tool class="QuestionableName" enabled="true" level="WARNING" enabled_by_default="true">
+    <option name="nameString" value="aa,abc,bad,bar,bar2,baz,baz1,baz2,baz3,bb,blah,bogus,bool,cc,dd,defau1t,dummy,dummy2,ee,fa1se,ff,foo,foo1,foo2,foo3,foobar,four,fred,fred1,fred2,gg,hh,hello,hello1,hello2,hello3,ii,nu11,one,silly,silly2,string,two,that,then,three,whi1e,var" />
+  </inspection_tool>
+  <inspection_tool class="RedundantFieldInitialization" enabled="true" level="WEAK WARNING" enabled_by_default="true" editorAttributes="INFO_ATTRIBUTES" />
+  <inspection_tool class="ReplaceAssignmentWithOperatorAssignment" enabled="true" level="WARNING" enabled_by_default="true">
+    <option name="ignoreLazyOperators" value="true" />
+    <option name="ignoreObscureOperators" value="false" />
+  </inspection_tool>
+  <inspection_tool class="ReturnSeparatedFromComputation" enabled="true" level="WEAK WARNING" enabled_by_default="true" editorAttributes="INFO_ATTRIBUTES" />
+  <inspection_tool class="SamePackageImport" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="SimplifiableAnnotation" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="SimplifiableEqualsExpression" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="SimplifiableIfStatement" enabled="true" level="WEAK WARNING" enabled_by_default="true" editorAttributes="INFO_ATTRIBUTES">
+    <option name="DONT_WARN_ON_CHAINED_ID" value="false" />
+  </inspection_tool>
+  <inspection_tool class="StaticMethodOnlyUsedInOneClass" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="StaticNonFinalField" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="StringConcatenationInFormatCall" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="SwitchExpressionCanBePushedDown" enabled="true" level="WEAK WARNING" enabled_by_default="true" editorAttributes="INFO_ATTRIBUTES" />
+  <inspection_tool class="SystemExit" enabled="true" level="WARNING" enabled_by_default="true">
+    <option name="ignoreInMainMethod" value="true" />
+  </inspection_tool>
+  <inspection_tool class="SystemGC" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="ThrowCaughtLocally" enabled="true" level="WARNING" enabled_by_default="true">
+    <option name="ignoreRethrownExceptions" value="false" />
+  </inspection_tool>
+  <inspection_tool class="TimeToString" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="TodoComment" enabled="true" level="WARNING" enabled_by_default="true">
+    <option name="onlyWarnOnEmpty" value="false" />
+  </inspection_tool>
+  <inspection_tool class="TooBroadCatch" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="TooBroadThrows" enabled="true" level="WARNING" enabled_by_default="true">
+    <option name="onlyWarnOnRootExceptions" value="true" />
+    <option name="hiddenExceptionsThreshold" value="5" />
+  </inspection_tool>
+  <inspection_tool class="TypeMayBeWeakened" enabled="true" level="WARNING" enabled_by_default="true">
+    <option name="useRighthandTypeAsWeakestTypeInAssignments" value="true" />
+    <option name="useParameterizedTypeForCollectionMethods" value="true" />
+    <option name="doNotWeakenToJavaLangObject" value="true" />
+    <option name="onlyWeakentoInterface" value="true" />
+    <option name="doNotWeakenInferredVariableType" value="true" />
+  </inspection_tool>
+  <inspection_tool class="TypeParameterExtendsFinalClass" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="UncheckedExceptionClass" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="UnnecessarilyQualifiedStaticUsage" enabled="true" level="WARNING" enabled_by_default="true">
+    <option name="m_ignoreStaticFieldAccesses" value="false" />
+    <option name="m_ignoreStaticMethodCalls" value="false" />
+    <option name="m_ignoreStaticAccessFromStaticContext" value="false" />
+  </inspection_tool>
+  <inspection_tool class="UnnecessarilyQualifiedStaticallyImportedElement" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="UnnecessaryBlockStatement" enabled="true" level="WEAK WARNING" enabled_by_default="true" editorAttributes="INFO_ATTRIBUTES">
+    <option name="ignoreSwitchBranches" value="true" />
+  </inspection_tool>
+  <inspection_tool class="UnnecessaryConstantArrayCreationExpression" enabled="true" level="WEAK WARNING" enabled_by_default="true" editorAttributes="INFO_ATTRIBUTES" />
+  <inspection_tool class="UnnecessaryConstructor" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="UnnecessaryFinalOnLocalVariableOrParameter" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="UnnecessaryFullyQualifiedName" enabled="true" level="WEAK WARNING" enabled_by_default="true" editorAttributes="INFO_ATTRIBUTES">
+    <option name="m_ignoreJavadoc" value="false" />
+    <option name="ignoreInModuleStatements" value="true" />
+  </inspection_tool>
+  <inspection_tool class="UnnecessaryParentheses" enabled="true" level="WEAK WARNING" enabled_by_default="true" editorAttributes="INFO_ATTRIBUTES">
+    <option name="ignoreClarifyingParentheses" value="false" />
+    <option name="ignoreParenthesesOnConditionals" value="false" />
+    <option name="ignoreParenthesesOnLambdaParameter" value="false" />
+  </inspection_tool>
+  <inspection_tool class="UpperCaseFieldNameNotConstant" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="UseOfAnotherObjectsPrivateField" enabled="true" level="WARNING" enabled_by_default="true">
+    <option name="ignoreSameClass" value="true" />
+    <option name="ignoreEquals" value="true" />
+  </inspection_tool>
+  <inspection_tool class="UseOfClone" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="UseOfConcreteClassMerged" />
+  <inspection_tool class="UseOfObsoleteDateTimeApi" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="UtilityClassWithPublicConstructor" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="UtilityClassWithoutPrivateConstructor" enabled="true" level="WARNING" enabled_by_default="true">
+    <option name="ignorableAnnotations">
+      <value />
+    </option>
+    <option name="ignoreClassesWithOnlyMain" value="false" />
+  </inspection_tool>
+  <inspection_tool class="VariableNotUsedInsideIf" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="WeakerAccess" enabled="true" level="WARNING" enabled_by_default="true">
+    <option name="SUGGEST_PACKAGE_LOCAL_FOR_MEMBERS" value="true" />
+    <option name="SUGGEST_PACKAGE_LOCAL_FOR_TOP_CLASSES" value="true" />
+    <option name="SUGGEST_PRIVATE_FOR_INNERS" value="true" />
+  </inspection_tool>
+</profile>

--- a/src/main/resources/Project_Default.xml
+++ b/src/main/resources/Project_Default.xml
@@ -59,7 +59,6 @@
     <option name="ignoreLocalVariables" value="false" />
     <option name="ignorePrivateMethodsAndFields" value="false" />
   </inspection_tool>
-  <inspection_tool class="DiamondCanBeReplacedWithExplicitTypeArguments" enabled="true" level="WEAK WARNING" enabled_by_default="true" editorAttributes="INFO_ATTRIBUTES" />
   <inspection_tool class="DollarSignInName" enabled="true" level="WARNING" enabled_by_default="true" />
   <inspection_tool class="DoubleBraceInitialization" enabled="true" level="WEAK WARNING" enabled_by_default="true" editorAttributes="INFO_ATTRIBUTES" />
   <inspection_tool class="DuplicateStringLiteralInspection" enabled="true" level="WARNING" enabled_by_default="true">


### PR DESCRIPTION
### Color changes

The old code did not handle the light and dark theme properly, and the default highlighter color was unreadable in the light theme:
![old_color_white_theme](https://github.com/user-attachments/assets/b001da48-bd59-477b-80a2-03d1a713d9ad)

This has been changed to a much more pleasant color:
![new_white_theme](https://github.com/user-attachments/assets/de52f2f9-a118-409b-974a-5c5565301d48)

Similarly for the dark theme, the color has been adjusted to be more pleasant.

This is the before:
![image](https://github.com/user-attachments/assets/1f00a0d3-6f2c-46a9-8953-aa18854016bf)

and this is what it was changed to

![Screenshot 2025-01-13 085119](https://github.com/user-attachments/assets/1debcf36-0b14-4883-9af1-6e709406f39b)

Internally an extra class called `ThemeColor` has been introduced. Currently it does the same things that `JBColor` does, but in the future, it will be changed to accommodate new features (like a nested annotation having a different highlighter color or buttons having different highlighter colors). This would not be so easy with a `JBColor`.

The old code did not support changing the transparency of the highlighter color, this is now supported.

#### Regarding migrations

With the types changed, loading an old config, would have crashed the plugin. The code has been extended to migrate old values to the new format. Additionally, it will migrate the old default highlighter color to the new one. The other colors are not migrated, because they haven't been changed.

### Automatically selects the right exercise, based on the selected config

This PR will close #92.

When intelligrade was started, it loaded the config that had been selected previously and defaulted to the first exercise in the list.

Now one can select the config, and it will automatically select the first exercise that can be used with the config.

### Save will cleanup the assessment

The code will now remove the local files and close the assessment after the save was pressed in this menu:
![image](https://github.com/user-attachments/assets/5f35f0a7-8a95-4154-b4d1-82066f92bd88)

This removes the need to press the save button and then the close button.

### Automatically open a file when there is no main method present

This PR will close #88.

The code does nothing fancy; it will select the first class that it encounters.

### When a line is selected via double-click it highlights the following line too.

This PR will close #93. Turns out this was a misinterpretation of the offset. The end offset is exclusive in the text range. That resulted in the wrong selection when double-clicking a line.

In addition to that, I fixed some potential threading problems (according to the javadoc, some methods must be called in a read action).

### Automatically set inspection profile

With this PR an inspection profile is automatically set in the cloned submission. This PR closes #91.

### Add support for buttons without visible highlighting

It will now look like this for certain annotations:
![image](https://github.com/user-attachments/assets/b64797d1-0871-494d-a6d6-c36c66dffb58)

Note that there is a pen on the left side, but the line is not highlighted. This is intentional.