### PR TITLE
Resolve some bugs and rewrite some parts in kotlin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id("org.jetbrains.intellij.platform") version "2.6.0"
     id 'java'
     id 'com.diffplug.spotless' version '7.0.3'
+    id 'org.jetbrains.kotlin.jvm' version '2.1.20'
 }
 
 group 'edu.kit.kastel.sdq'
@@ -11,6 +12,12 @@ version '1.0-SNAPSHOT'
 java {
     sourceCompatibility = "21"
     targetCompatibility = "21"
+}
+
+kotlin {
+    jvmToolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
 }
 
 repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,5 @@
 JUNIT_VERSION = 4.13.2
 ARCHUNIT_VERSION = 1.4.1
+
+# Increase the heap size for Gradle to handle larger projects
+org.gradle.jvmargs=-Xmx1024m -XX:MaxMetaspaceSize=768m

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/highlighter/HighlighterManager.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/highlighter/HighlighterManager.java
@@ -169,13 +169,14 @@ public class HighlighterManager {
                     .map(endColumn -> document.getLineStartOffset(location.end().line()) + endColumn)
                     .orElseGet(() -> document.getLineEndOffset(location.end().line()));
 
+            var range = HighlighterTargetArea.EXACT_RANGE;
+            if (startOffset == endOffset) {
+                // if the start and end offset are the same, we highlight the entire line
+                range = HighlighterTargetArea.LINES_IN_RANGE;
+            }
+
             highlighters.add(editor.getMarkupModel()
-                    .addRangeHighlighter(
-                            startOffset,
-                            endOffset,
-                            HighlighterLayer.SELECTION - 1,
-                            attributes,
-                            HighlighterTargetArea.EXACT_RANGE));
+                    .addRangeHighlighter(startOffset, endOffset, HighlighterLayer.SELECTION - 1, attributes, range));
         }
 
         // use the first highlighter for the gutter icon

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/state/PluginState.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/state/PluginState.java
@@ -2,11 +2,8 @@
 package edu.kit.kastel.sdq.intelligrade.state;
 
 import java.io.IOException;
-import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -17,30 +14,25 @@ import java.util.function.Consumer;
 
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.openapi.fileEditor.FileEditorManager;
-import com.intellij.openapi.progress.ProgressIndicator;
-import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.ui.MessageDialogBuilder;
 import com.intellij.ui.jcef.JBCefApp;
 import edu.kit.kastel.sdq.artemis4j.ArtemisClientException;
-import edu.kit.kastel.sdq.artemis4j.ArtemisNetworkException;
 import edu.kit.kastel.sdq.artemis4j.client.ArtemisInstance;
 import edu.kit.kastel.sdq.artemis4j.grading.ArtemisConnection;
-import edu.kit.kastel.sdq.artemis4j.grading.Assessment;
-import edu.kit.kastel.sdq.artemis4j.grading.MoreRecentSubmissionException;
 import edu.kit.kastel.sdq.artemis4j.grading.ProgrammingExercise;
 import edu.kit.kastel.sdq.artemis4j.grading.ProgrammingSubmission;
-import edu.kit.kastel.sdq.artemis4j.grading.metajson.AnnotationMappingException;
 import edu.kit.kastel.sdq.artemis4j.grading.penalty.GradingConfig;
 import edu.kit.kastel.sdq.artemis4j.grading.penalty.InvalidGradingConfigException;
-import edu.kit.kastel.sdq.intelligrade.extensions.guis.SplashDialog;
+import edu.kit.kastel.sdq.intelligrade.AssessmentTracker;
+import edu.kit.kastel.sdq.intelligrade.EndAssessmentService;
+import edu.kit.kastel.sdq.intelligrade.ReopenAssessmentService;
+import edu.kit.kastel.sdq.intelligrade.StartAssessmentService;
+import edu.kit.kastel.sdq.intelligrade.SubmitAction;
 import edu.kit.kastel.sdq.intelligrade.extensions.settings.ArtemisCredentialsProvider;
 import edu.kit.kastel.sdq.intelligrade.extensions.settings.ArtemisSettingsState;
 import edu.kit.kastel.sdq.intelligrade.login.CefUtils;
 import edu.kit.kastel.sdq.intelligrade.utils.ArtemisUtils;
 import edu.kit.kastel.sdq.intelligrade.utils.IntellijUtil;
-import org.apache.commons.io.FileUtils;
-import org.jetbrains.annotations.NotNull;
 
 public class PluginState {
     private static final Logger LOG = Logger.getInstance(PluginState.class);
@@ -56,6 +48,28 @@ public class PluginState {
     private ProgrammingExercise activeExercise;
 
     private ActiveAssessment activeAssessment;
+
+    private PluginState() {
+        // The code for opening/closing assessments is in kotlin, but this class keeps track of the active assessment
+        // as well.
+        //
+        // With this, PluginState will be notified when an assessment changes.
+        AssessmentTracker.INSTANCE.addListener(changedAssessment -> {
+            activeAssessment = changedAssessment;
+
+            if (changedAssessment == null) {
+                // Notify listeners that the assessment was closed
+                for (Runnable listener : assessmentClosedListeners) {
+                    listener.run();
+                }
+            } else {
+                // Notify listeners that the assessment was started
+                for (Consumer<ActiveAssessment> listener : assessmentStartedListeners) {
+                    listener.accept(changedAssessment);
+                }
+            }
+        });
+    }
 
     public static PluginState getInstance() {
         if (pluginState == null) {
@@ -164,7 +178,7 @@ public class PluginState {
     }
 
     public void startNextAssessment(int correctionRound) {
-        if (activeAssessment != null) {
+        if (isAssessing()) {
             ArtemisUtils.displayFinishAssessmentFirstBalloon();
             return;
         }
@@ -179,76 +193,48 @@ public class PluginState {
             return;
         }
 
-        new StartAssessmentTask(correctionRound, gradingConfig.get()).queue();
+        StartAssessmentService.getInstance(IntellijUtil.getActiveProject())
+                .queue(correctionRound, gradingConfig.get(), activeExercise);
     }
 
     public void saveAssessment() {
-        if (activeAssessment == null) {
+        if (!isAssessing()) {
             ArtemisUtils.displayNoAssessmentBalloon();
             return;
         }
 
-        try {
-            activeAssessment.getAssessment().save();
-            ArtemisUtils.displayGenericInfoBalloon("Assessment saved", "The assessment has been saved.");
-            this.cleanupAssessment();
-        } catch (ArtemisNetworkException e) {
-            LOG.warn(e);
-            ArtemisUtils.displayNetworkErrorBalloon("Could not save assessment", e);
-        } catch (AnnotationMappingException e) {
-            LOG.warn(e);
-            ArtemisUtils.displayGenericErrorBalloon(
-                    "Could not save assessment",
-                    "Failed to serialize the assessment. This is a serious bug; please contact the Übungsleitung!");
-        }
+        EndAssessmentService.getInstance(IntellijUtil.getActiveProject()).queue(SubmitAction.SAVE);
     }
 
     public void submitAssessment() {
-        if (activeAssessment == null) {
+        if (!isAssessing()) {
             ArtemisUtils.displayNoAssessmentBalloon();
             return;
         }
 
-        try {
-            activeAssessment.getAssessment().submit();
-            this.cleanupAssessment();
-        } catch (ArtemisNetworkException e) {
-            LOG.warn(e);
-            ArtemisUtils.displayNetworkErrorBalloon("Could not submit assessment", e);
-        } catch (AnnotationMappingException e) {
-            LOG.warn(e);
-            ArtemisUtils.displayGenericErrorBalloon(
-                    "Could not submit assessment",
-                    "Failed to serialize the assessment. This is a serious bug; please contact the Übungsleitung!");
-        }
+        EndAssessmentService.getInstance(IntellijUtil.getActiveProject()).queue(SubmitAction.SUBMIT);
     }
 
     public void cancelAssessment() {
-        if (activeAssessment == null) {
+        if (!isAssessing()) {
             ArtemisUtils.displayNoAssessmentBalloon();
             return;
         }
 
-        try {
-            activeAssessment.getAssessment().cancel();
-            this.cleanupAssessment();
-        } catch (ArtemisNetworkException e) {
-            LOG.warn(e);
-            ArtemisUtils.displayNetworkErrorBalloon("Could not submit assessment", e);
-        }
+        EndAssessmentService.getInstance(IntellijUtil.getActiveProject()).queue(SubmitAction.CANCEL);
     }
 
     public void closeAssessment() {
-        if (activeAssessment == null) {
+        if (!isAssessing()) {
             ArtemisUtils.displayNoAssessmentBalloon();
             return;
         }
 
-        this.cleanupAssessment();
+        EndAssessmentService.getInstance(IntellijUtil.getActiveProject()).queue(SubmitAction.CLOSE);
     }
 
     public void reopenAssessment(ProgrammingSubmission submission) {
-        if (activeAssessment != null) {
+        if (isAssessing()) {
             ArtemisUtils.displayFinishAssessmentFirstBalloon();
             return;
         }
@@ -263,7 +249,7 @@ public class PluginState {
             return;
         }
 
-        new ReopenAssessmentTask(submission, gradingConfig.get()).queue();
+        ReopenAssessmentService.getInstance(IntellijUtil.getActiveProject()).queue(submission, gradingConfig.get());
     }
 
     public Optional<ProgrammingExercise> getActiveExercise() {
@@ -292,7 +278,8 @@ public class PluginState {
     private void resetState() {
         connection = null;
         activeExercise = null;
-        activeAssessment = null;
+
+        AssessmentTracker.INSTANCE.clearAssessment();
     }
 
     private CompletableFuture<String> retrieveJWT() {
@@ -336,90 +323,6 @@ public class PluginState {
         });
     }
 
-    private boolean initializeAssessment(Assessment assessment) {
-        try {
-            // Cleanup first, in case there are files left from a previous assessment
-            this.cleanupProjectDirectory();
-
-            // Clone the new submission
-            var clonedSubmission =
-                    switch (ArtemisSettingsState.getInstance().getVcsAccessOption()) {
-                        case SSH -> {
-                            // We need to switch the classloader here (same as
-                            // https://plugins.jetbrains.com/docs/intellij/plugin-class-loaders.html#using-serviceloader)
-                            // Somewhere deep in the auth libs, an instanceof check is performed, which returns false in
-                            // some cases where the same class was loaded with two different class loaders (the plugin
-                            // and the platform ones)
-                            Thread currentThread = Thread.currentThread();
-                            ClassLoader originalClassLoader = currentThread.getContextClassLoader();
-                            ClassLoader pluginClassLoader = this.getClass().getClassLoader();
-                            try {
-                                currentThread.setContextClassLoader(pluginClassLoader);
-                                yield assessment
-                                        .getSubmission()
-                                        .cloneViaSSHInto(IntellijUtil.getProjectRootDirectory());
-                            } finally {
-                                currentThread.setContextClassLoader(originalClassLoader);
-                            }
-                        }
-                        case TOKEN -> assessment
-                                .getSubmission()
-                                .cloneViaVCSTokenInto(IntellijUtil.getProjectRootDirectory(), null);
-                    };
-
-            // TODO: might have to be spawned in a background thread
-            IntellijUtil.setupProjectProfile();
-
-            // Refresh all files, so that they are up-to-date for the maven update
-            IntellijUtil.forceFilesSync(() -> {
-                // Force IntelliJ to update the Maven project
-                IntellijUtil.getMavenManager().forceUpdateAllProjectsOrFindAllAvailablePomFiles();
-            });
-
-            // Sometimes the SDK is not set properly, this will set the SDK if it is not set
-            IntellijUtil.updateProjectSDK();
-
-            this.activeAssessment = new ActiveAssessment(assessment, clonedSubmission);
-            for (Consumer<ActiveAssessment> listener : this.assessmentStartedListeners) {
-                listener.accept(activeAssessment);
-            }
-
-            return true;
-        } catch (ArtemisClientException e) {
-            LOG.warn(e);
-            ArtemisUtils.displayGenericErrorBalloon("Error cloning submission", e.getMessage());
-
-            // Cancel the assessment to prevent spurious locks
-            try {
-                assessment.cancel();
-            } catch (ArtemisNetworkException ex) {
-                LOG.warn(ex);
-                ArtemisUtils.displayGenericErrorBalloon("Failed to free the assessment lock", ex.getMessage());
-            }
-
-            return false;
-        }
-    }
-
-    private void cleanupAssessment() {
-        this.activeAssessment = null;
-
-        // Do not close the ClonedProgrammingSubmission, since this would try to delete the workspace file
-        // Instead, we delete the project directory manually
-        this.cleanupProjectDirectory();
-
-        // Tell IntelliJ's VCS manager that the Git repo is gone
-        // This prevents an annoying popup that warns about a missing Git root
-        IntellijUtil.forceFilesSync(() -> {
-            IntellijUtil.getVcsManager().setDirectoryMappings(List.of());
-            IntellijUtil.getVcsManager().fireDirectoryMappingsChanged();
-        });
-
-        for (Runnable assessmentClosedListener : this.assessmentClosedListeners) {
-            assessmentClosedListener.run();
-        }
-    }
-
     private Optional<GradingConfig> createGradingConfig() {
         var gradingConfigPath = ArtemisSettingsState.getInstance().getSelectedGradingConfigPath();
         if (gradingConfigPath == null) {
@@ -442,133 +345,6 @@ public class PluginState {
                 missingGradingConfigListener.run();
             }
             return Optional.empty();
-        }
-    }
-
-    private void cleanupProjectDirectory() {
-        // Close all open editors
-        var editorManager = FileEditorManager.getInstance(IntellijUtil.getActiveProject());
-        ApplicationManager.getApplication().invokeAndWait(() -> {
-            for (var editor : editorManager.getAllEditors()) {
-                editorManager.closeFile(editor.getFile());
-            }
-        });
-
-        var rootPath = IntellijUtil.getProjectRootDirectory();
-        // Delete all directory contents, but not the directory itself
-        try {
-            Files.walkFileTree(rootPath, new SimpleFileVisitor<>() {
-                @Override
-                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-                    FileUtils.forceDelete(file.toFile());
-                    return FileVisitResult.CONTINUE;
-                }
-
-                @Override
-                public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
-                    if (!dir.equals(rootPath)) {
-                        FileUtils.forceDelete(dir.toFile());
-                    }
-                    return FileVisitResult.CONTINUE;
-                }
-            });
-        } catch (IOException e) {
-            LOG.warn(e);
-            ArtemisUtils.displayGenericErrorBalloon("Error cleaning up project directory", e.getMessage());
-        }
-    }
-
-    private class StartAssessmentTask extends Task.Modal {
-        private final int correctionRound;
-        private final GradingConfig gradingConfig;
-
-        public StartAssessmentTask(int correctionRound, GradingConfig gradingConfig) {
-            super(IntellijUtil.getActiveProject(), "Starting Assessment", false);
-            this.correctionRound = correctionRound;
-            this.gradingConfig = gradingConfig;
-        }
-
-        @Override
-        public void run(@NotNull ProgressIndicator progressIndicator) {
-            try {
-                progressIndicator.setText("Locking...");
-                var nextAssessment = activeExercise.tryLockNextSubmission(correctionRound, gradingConfig);
-                if (nextAssessment.isPresent()) {
-                    progressIndicator.setText("Cloning...");
-                    if (!initializeAssessment(nextAssessment.get())) {
-                        return;
-                    }
-
-                    SplashDialog.showMaybe();
-
-                    // Now everything is done - the submission is properly locked, and the repository is cloned
-                    if (activeAssessment.getAssessment().getAnnotations().isEmpty()) {
-                        activeAssessment.runAutograder();
-                    } else {
-                        ArtemisUtils.displayGenericInfoBalloon(
-                                "Skipping Autograder",
-                                "The submission already has annotations. Skipping the Autograder.");
-                    }
-
-                    ArtemisUtils.displayGenericInfoBalloon(
-                            "Assessment started",
-                            "You can now grade the submission. Please make sure that are familiar with all "
-                                    + "grading guidelines.");
-                } else {
-                    ArtemisUtils.displayGenericInfoBalloon(
-                            "Could not start assessment",
-                            "There are no more submissions to assess. Thanks for your work :)");
-                }
-            } catch (ArtemisNetworkException e) {
-                LOG.warn(e);
-                ArtemisUtils.displayNetworkErrorBalloon("Could not lock assessment", e);
-            } catch (AnnotationMappingException e) {
-                LOG.warn(e);
-                ArtemisUtils.displayGenericErrorBalloon(
-                        "Could not parse assessment",
-                        "Could not parse previous assessment. This is a serious bug; please contact the "
-                                + "Übungsleitung!");
-            }
-        }
-    }
-
-    private class ReopenAssessmentTask extends Task.Modal {
-        private final ProgrammingSubmission submission;
-        private final GradingConfig gradingConfig;
-
-        public ReopenAssessmentTask(ProgrammingSubmission submission, GradingConfig gradingConfig) {
-            super(IntellijUtil.getActiveProject(), "Reopening Assessment", false);
-            this.submission = submission;
-            this.gradingConfig = gradingConfig;
-        }
-
-        @Override
-        public void run(@NotNull ProgressIndicator progressIndicator) {
-            try {
-                progressIndicator.setText("Locking...");
-                var assessment = submission.tryLock(gradingConfig);
-                if (assessment.isPresent()) {
-                    progressIndicator.setText("Cloning...");
-                    initializeAssessment(assessment.get());
-                } else {
-                    ArtemisUtils.displayGenericErrorBalloon(
-                            "Failed to reopen assessment", "Most likely, your lock has been taken by someone else.");
-                }
-
-            } catch (ArtemisNetworkException e) {
-                LOG.warn(e);
-                ArtemisUtils.displayNetworkErrorBalloon("Could not lock assessment", e);
-            } catch (AnnotationMappingException e) {
-                LOG.warn(e);
-                ArtemisUtils.displayGenericErrorBalloon(
-                        "Could not parse assessment",
-                        "Could not parse previous assessment. This is a serious bug; please contact the "
-                                + "Übungsleitung!");
-            } catch (MoreRecentSubmissionException e) {
-                LOG.warn(e);
-                ArtemisUtils.displayGenericErrorBalloon(
-                        "Could not reopen assessment", "The student has submitted a newer version of his code.");
-            }
         }
     }
 }

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/utils/ArtemisUtils.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/utils/ArtemisUtils.java
@@ -1,14 +1,19 @@
-/* Licensed under EPL-2.0 2024. */
+/* Licensed under EPL-2.0 2024-2025. */
 package edu.kit.kastel.sdq.intelligrade.utils;
 
 import java.net.HttpURLConnection;
 import java.net.URI;
+import java.nio.file.Path;
 
 import com.intellij.notification.NotificationGroupManager;
 import com.intellij.notification.NotificationType;
+import edu.kit.kastel.sdq.artemis4j.ArtemisClientException;
 import edu.kit.kastel.sdq.artemis4j.ArtemisNetworkException;
 import edu.kit.kastel.sdq.artemis4j.client.AssessmentType;
+import edu.kit.kastel.sdq.artemis4j.grading.Assessment;
+import edu.kit.kastel.sdq.artemis4j.grading.ClonedProgrammingSubmission;
 import edu.kit.kastel.sdq.artemis4j.grading.ProgrammingSubmission;
+import edu.kit.kastel.sdq.intelligrade.state.PluginState;
 
 /**
  * Utility Class to handle Artemis related common tasks such as
@@ -23,6 +28,24 @@ public final class ArtemisUtils {
             return connection.getResponseCode() == HttpURLConnection.HTTP_OK;
         } catch (Exception ex) {
             return false;
+        }
+    }
+
+    public static ClonedProgrammingSubmission cloneViaSSH(Assessment assessment, Path workspacePath)
+            throws ArtemisClientException {
+        // We need to switch the classloader here (same as
+        // https://plugins.jetbrains.com/docs/intellij/plugin-class-loaders.html#using-serviceloader)
+        // Somewhere deep in the auth libs, an instanceof check is performed, which returns false in
+        // some cases where the same class was loaded with two different class loaders (the plugin
+        // and the platform ones)
+        var currentThread = Thread.currentThread();
+        var originalClassLoader = currentThread.getContextClassLoader();
+        var pluginClassLoader = PluginState.getInstance().getClass().getClassLoader();
+        try {
+            currentThread.setContextClassLoader(pluginClassLoader);
+            return assessment.getSubmission().cloneViaSSHInto(workspacePath);
+        } finally {
+            currentThread.setContextClassLoader(originalClassLoader);
         }
     }
 

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/utils/CodeSelection.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/utils/CodeSelection.java
@@ -36,12 +36,18 @@ public record CodeSelection(Path path, LineColumn start, LineColumn end) {
         var path = editor.getVirtualFile().toNioPath();
 
         int startLine = editor.getDocument().getLineNumber(startOffset);
-        // the end is not inclusive, therefore 1 is subtracted to get the correct line number
-        int endLine = editor.getDocument().getLineNumber(endOffset - 1);
-
         // The column is the offset in the line (0-based), sometimes only parts of a line are highlighted
         int startColumn = startOffset - editor.getDocument().getLineStartOffset(startLine);
+
+        // the end is not inclusive, therefore 1 is subtracted to get the correct line number
+        int endLine = editor.getDocument().getLineNumber(endOffset - 1);
         int endColumn = endOffset - editor.getDocument().getLineStartOffset(endLine);
+        // when the start and end offset are the same, the subtraction of 1 would lead to an end offset
+        // that is before the start offset
+        if (startOffset == endOffset) {
+            endLine = startLine;
+            endColumn = startColumn;
+        }
 
         return Optional.of(
                 new CodeSelection(path, new LineColumn(startLine, startColumn), new LineColumn(endLine, endColumn)));

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/utils/IntellijUtil.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/utils/IntellijUtil.java
@@ -5,36 +5,22 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Objects;
 
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ReadAction;
-import com.intellij.openapi.application.WriteAction;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
-import com.intellij.openapi.projectRoots.ProjectJdkTable;
-import com.intellij.openapi.projectRoots.Sdk;
-import com.intellij.openapi.projectRoots.SdkTypeId;
-import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.vcs.impl.ProjectLevelVcsManagerImpl;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.openapi.vfs.newvfs.RefreshQueue;
 import com.intellij.ui.JBColor;
-import com.intellij.util.lang.JavaVersion;
 import edu.kit.kastel.sdq.artemis4j.grading.Annotation;
 import edu.kit.kastel.sdq.intelligrade.state.ActiveAssessment;
-import org.jetbrains.idea.maven.project.MavenProjectsManager;
 
 public final class IntellijUtil {
-    private static final Logger LOG = Logger.getInstance(IntellijUtil.class);
-    private static final String JAVA_SDK_TYPE_NAME = "JavaSDK";
-    private static final int TARGET_SDK_VERSION = 17;
+    public static final String JAVA_SDK_TYPE_NAME = "JavaSDK";
+    public static final int TARGET_SDK_VERSION = 21;
 
     private IntellijUtil() {
         throw new IllegalStateException("Utility class");
@@ -48,78 +34,27 @@ public final class IntellijUtil {
         return FileEditorManager.getInstance(getActiveProject()).getSelectedTextEditor();
     }
 
+    /**
+     * Returns the root directory of the currently active project.
+     * This is the directory under which the project configuration files (like .idea) are stored.
+     * There are some caveats, see {@link Project#getBasePath()}.
+     *
+     * @return the path to the root directory of the active project
+     */
     public static Path getProjectRootDirectory() {
         return Path.of(getActiveProject().getBasePath());
-    }
-
-    public static MavenProjectsManager getMavenManager() {
-        return MavenProjectsManager.getInstance(getActiveProject());
-    }
-
-    public static void forceFilesSync(Runnable afterSyncAction) {
-        var rootVirtualFile = Objects.requireNonNull(
-                VfsUtil.findFileByIoFile(getProjectRootDirectory().toFile(), true));
-        var session = RefreshQueue.getInstance().createSession(true, true, afterSyncAction);
-        session.addFile(rootVirtualFile);
-        session.launch();
     }
 
     public static ProjectLevelVcsManagerImpl getVcsManager() {
         return ProjectLevelVcsManagerImpl.getInstanceImpl(IntellijUtil.getActiveProject());
     }
 
-    /**
-     * Checks if the active project has a JDK set and if not, it will set a JDK.
-     */
-    public static void updateProjectSDK() {
-        // It is amazing how much is possible, the difficult part is finding the right classes
-        // that do what you want... this was much more work than it looks like.
-        var manager = ProjectRootManager.getInstance(getActiveProject());
-
-        // check if SDK is already set
-        var projectSdk = manager.getProjectSdk();
-        if (projectSdk != null) {
-            LOG.debug("SDK already set: " + projectSdk.getVersionString());
-            return;
-        }
-
-        // if not, set the SDK.
-
-        var jdkTable = ProjectJdkTable.getInstance();
-
-        SdkTypeId javaSdkTypeId = jdkTable.getSdkTypeByName(JAVA_SDK_TYPE_NAME);
-
-        var availableSdks = ProjectJdkTable.getInstance().getSdksOfType(javaSdkTypeId);
-        if (availableSdks.isEmpty()) {
-            LOG.warn("No SDK found, please install a JDK");
-            return;
-        }
-
-        // they are sorted starting from the latest version
-        List<Sdk> sortedSdks = availableSdks.stream()
-                .filter(sdk -> sdk.getVersionString() != null && JavaVersion.tryParse(sdk.getVersionString()) != null)
-                .sorted(Comparator.comparing((Sdk sdk) -> JavaVersion.parse(sdk.getVersionString())))
-                .toList();
-
-        LOG.debug("Available SDKs: " + sortedSdks);
-        for (var availableSdk : availableSdks) {
-            if (availableSdk.getVersionString() == null) {
-                continue;
-            }
-
-            if (JavaVersion.parse(availableSdk.getVersionString()).isAtLeast(TARGET_SDK_VERSION)) {
-                // update the project sdk, this has to be done in a dedicated thread to prevent crashes
-                ApplicationManager.getApplication()
-                        .invokeLater(() -> WriteAction.run(() -> manager.setProjectSdk(availableSdk)));
-                return;
-            }
-        }
-
-        LOG.error("No suitable SDK found, please install a JDK with version " + TARGET_SDK_VERSION + " or higher");
-    }
-
     private static String loadInspectionsProfile() throws IOException {
         try (var in = IntellijUtil.class.getResourceAsStream("/Project_Default.xml")) {
+            if (in == null) {
+                throw new IllegalStateException("Default inspections profile not found in resources");
+            }
+
             return new String(in.readAllBytes(), StandardCharsets.UTF_8);
         }
     }

--- a/src/main/kotlin/edu/kit/kastel/sdq/intelligrade/AssessmentTracker.kt
+++ b/src/main/kotlin/edu/kit/kastel/sdq/intelligrade/AssessmentTracker.kt
@@ -24,7 +24,6 @@ import edu.kit.kastel.sdq.intelligrade.utils.IntellijUtil
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.apache.commons.lang3.reflect.MethodUtils
-import org.eclipse.jgit.internal.storage.file.WindowCache
 import org.eclipse.jgit.lib.RepositoryCache
 import org.eclipse.jgit.storage.file.WindowCacheConfig
 import java.io.IOException

--- a/src/main/kotlin/edu/kit/kastel/sdq/intelligrade/AssessmentTracker.kt
+++ b/src/main/kotlin/edu/kit/kastel/sdq/intelligrade/AssessmentTracker.kt
@@ -1,0 +1,242 @@
+package edu.kit.kastel.sdq.intelligrade
+
+import com.intellij.dvcs.repo.VcsRepositoryManager
+import com.intellij.openapi.application.EDT
+import com.intellij.openapi.application.writeAction
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vcs.VcsDirectoryMapping
+import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.VirtualFileVisitor
+import edu.kit.kastel.sdq.artemis4j.ArtemisClientException
+import edu.kit.kastel.sdq.artemis4j.ArtemisNetworkException
+import edu.kit.kastel.sdq.artemis4j.client.AnnotationSource
+import edu.kit.kastel.sdq.artemis4j.grading.Annotation
+import edu.kit.kastel.sdq.artemis4j.grading.Assessment
+import edu.kit.kastel.sdq.artemis4j.grading.ClonedProgrammingSubmission
+import edu.kit.kastel.sdq.intelligrade.extensions.settings.ArtemisSettingsState
+import edu.kit.kastel.sdq.intelligrade.extensions.settings.VCSAccessOption
+import edu.kit.kastel.sdq.intelligrade.state.ActiveAssessment
+import edu.kit.kastel.sdq.intelligrade.utils.ArtemisUtils
+import edu.kit.kastel.sdq.intelligrade.utils.IntellijUtil
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.apache.commons.lang3.reflect.MethodUtils
+import org.eclipse.jgit.internal.storage.file.WindowCache
+import org.eclipse.jgit.lib.RepositoryCache
+import org.eclipse.jgit.storage.file.WindowCacheConfig
+import java.io.IOException
+import java.lang.Exception
+import java.nio.file.Path
+
+fun interface AssessmentListener {
+    fun update(value: ActiveAssessment?)
+}
+
+private val LOG = logger<AssessmentTracker>()
+
+/**
+ * This object (singleton) keeps track of the current assessment.
+ */
+object AssessmentTracker {
+    var activeAssessment: ActiveAssessment? = null
+    private val listeners: MutableList<AssessmentListener> = mutableListOf()
+
+    fun addListener(listener: AssessmentListener) {
+        listeners.add(listener)
+    }
+
+    private fun updateAssessment(assessment: ActiveAssessment?) {
+        this.activeAssessment = assessment
+        for (listener in listeners) {
+            listener.update(activeAssessment)
+        }
+    }
+
+    fun clearAssessment() {
+        updateAssessment(null)
+    }
+
+    suspend fun cleanupAssessment() {
+        // Do not close the ClonedProgrammingSubmission, since this would try to delete the workspace file
+        // Instead, we delete the project directory manually
+        this.cleanupProjectDirectory()
+
+        // Clear active assessment and notify listeners
+        clearAssessment()
+    }
+
+    @Throws(ArtemisClientException::class)
+    suspend fun cloneSubmission(workspacePath: Path?, assessment: Assessment): ClonedProgrammingSubmission? {
+        // Clone the new submission
+        val submission = when (ArtemisSettingsState.getInstance().vcsAccessOption) {
+            VCSAccessOption.SSH -> withContext(Dispatchers.IO) {
+                ArtemisUtils.cloneViaSSH(assessment, workspacePath)
+            }
+            VCSAccessOption.TOKEN -> withContext(Dispatchers.IO) {
+                assessment
+                    .submission
+                    .cloneViaVCSTokenInto(workspacePath, null)
+            }
+        }
+
+        // Force a file sync to ensure the VFS knows about the new files:
+        ProjectUtil.forceFilesSync()
+
+        return submission
+    }
+
+    suspend fun initializeAssessment(assessment: Assessment): ActiveAssessment? {
+        try {
+            // Cleanup first, in case there are files left from a previous assessment
+            cleanupProjectDirectory()
+
+            val baseDirectory = IntellijUtil.getProjectRootDirectory()
+            val clonedSubmission: ClonedProgrammingSubmission? = cloneSubmission(baseDirectory, assessment)
+
+            withContext(Dispatchers.IO) {
+                IntellijUtil.setupProjectProfile()
+                // Force a file sync to ensure the VFS knows about the new files:
+                ProjectUtil.forceFilesSync()
+            }
+
+            val mavenInitializer = MavenProjectInitializer.getInstance(IntellijUtil.getActiveProject());
+            mavenInitializer.addListener {
+                // Sometimes the SDK is not set properly, this will set the SDK if it is not set
+                ProjectUtil.updateProjectSDK()
+            }
+
+            mavenInitializer.start()
+
+            updateAssessment(ActiveAssessment(assessment, clonedSubmission))
+
+            return activeAssessment
+        } catch (e: ArtemisClientException) {
+            LOG.warn(e)
+            ArtemisUtils.displayGenericErrorBalloon("Error cloning submission", e.message)
+
+            // Cancel the assessment to prevent spurious locks
+            // but only if the assessment does not have any user-made annotations yet (non autograder annotations):
+            val hasUserAnnotations = assessment.annotations.stream()
+                .anyMatch { annotation: Annotation? ->
+                    assessment.correctionRound == 0
+                            && annotation!!.source == AnnotationSource.MANUAL_FIRST_ROUND
+                            || assessment.correctionRound == 1
+                            && annotation!!.source == AnnotationSource.MANUAL_SECOND_ROUND
+                }
+
+            try {
+                if (!hasUserAnnotations) {
+                    assessment.cancel()
+                }
+            } catch (ex: ArtemisNetworkException) {
+                LOG.warn(ex)
+                ArtemisUtils.displayGenericErrorBalloon("Failed to free the assessment lock", ex.message)
+            }
+
+            return null
+        }
+    }
+
+    private suspend fun unregisterGitRepository(project: Project) {
+        // There is a lot of git stuff going on in the background, some of which will complain
+        // when the .git directory is deleted.
+
+        // Indicate to the VCS that we are about to delete the project directory
+        IntellijUtil.getVcsManager().directoryMappings = mutableListOf<VcsDirectoryMapping?>()
+        IntellijUtil.getVcsManager().fireDirectoryMappingsChanged()
+
+        val repositoryManager = VcsRepositoryManager.getInstance(project)
+        if (!repositoryManager.getRepositories().isEmpty()) {
+            // When deleting the .git folder, the git4idea plugin will throw an exception when the .git/HEAD file
+            // is deleted.
+            //
+            // It seems to be watching the .git directory in the background.
+
+            // The VcsRepositoryManager seems to keep track of the repositories. We need it to dispose the class
+            // that keeps track of the deleted repository.
+            //
+            // There isn't much code in the class, and even less that changes the list of repositories.
+            // The below method will make the manager check which repositories are no longer mapped
+            // (mappings were removed in the above calls)
+            //
+            // Sadly this method is not public, so reflection comes to the rescue.
+            LOG.debug("Repositories before update: ${repositoryManager.getRepositories()}")
+            try {
+                MethodUtils.invokeMethod(repositoryManager, true, "checkAndUpdateRepositoryCollection", null)
+            } catch (e: Exception) {
+                // If anything crashes here, it is not a big deal, because the code still works.
+                LOG.warn(e)
+            }
+            LOG.debug("Repositories after update: ${repositoryManager.getRepositories()}")
+        }
+
+        // This is a workaround for an issue with the jgit library that is used by artemis4j:
+        withContext(Dispatchers.IO) {
+            RepositoryCache.clear()
+            WindowCache.reconfigure(WindowCacheConfig())
+        }
+
+    }
+
+    suspend fun cleanupProjectDirectory() {
+        // Close all open editors
+        val project = IntellijUtil.getActiveProject()
+        val editorManager = FileEditorManager.getInstance(project)
+        for (editor in editorManager.allEditors) {
+            withContext(Dispatchers.EDT) {
+                editorManager.closeFile(editor.file)
+            }
+        }
+
+        val rootFile = ProjectUtil.getProjectRootVirtualFile(project)
+        if (rootFile == null) {
+            LOG.error("Project root virtual file is null, cannot clean up project directory")
+            return
+        }
+
+        this.unregisterGitRepository(project)
+
+        // Delete all directory contents, but not the directory itself
+        val deletionQueue = mutableListOf<VirtualFile>()
+        withContext(Dispatchers.IO) {
+            VfsUtil.visitChildrenRecursively(rootFile, object : VirtualFileVisitor<Void?>() {
+                override fun visitFile(file: VirtualFile): Boolean {
+                    if (!file.isDirectory) {
+                        deletionQueue.add(file)
+                        return false
+                    }
+
+                    return true
+                }
+
+                override fun afterChildrenVisited(file: VirtualFile) {
+                    // delete empty directories
+                    if (file.isDirectory && deletionQueue.containsAll(file.children.asList()) && file != rootFile) {
+                        deletionQueue.add(file)
+                    }
+                }
+            })
+        }
+
+        for (file in deletionQueue) {
+            delete(file)
+        }
+
+        // ensure that the VFS knows about the deleted files:
+        ProjectUtil.forceFilesSync()
+    }
+
+    private suspend fun delete(file: VirtualFile) {
+        withContext(Dispatchers.IO) {
+            try {
+                writeAction { file.delete(AssessmentTracker::class.java) }
+                LOG.debug("Deleted: " + file.presentableUrl)
+            } catch (exception: IOException) {
+                LOG.warn("Failed to delete: " + file.presentableUrl, exception)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/edu/kit/kastel/sdq/intelligrade/AssessmentTracker.kt
+++ b/src/main/kotlin/edu/kit/kastel/sdq/intelligrade/AssessmentTracker.kt
@@ -176,7 +176,7 @@ object AssessmentTracker {
         // This is a workaround for an issue with the jgit library that is used by artemis4j:
         withContext(Dispatchers.IO) {
             RepositoryCache.clear()
-            WindowCache.reconfigure(WindowCacheConfig())
+            WindowCacheConfig().install()
         }
 
     }

--- a/src/main/kotlin/edu/kit/kastel/sdq/intelligrade/AssessmentTracker.kt
+++ b/src/main/kotlin/edu/kit/kastel/sdq/intelligrade/AssessmentTracker.kt
@@ -101,7 +101,7 @@ object AssessmentTracker {
                 ProjectUtil.forceFilesSync()
             }
 
-            val mavenInitializer = MavenProjectInitializer.getInstance(IntellijUtil.getActiveProject());
+            val mavenInitializer = MavenProjectInitializer.getInstance(IntellijUtil.getActiveProject())
             mavenInitializer.addListener {
                 // Sometimes the SDK is not set properly, this will set the SDK if it is not set
                 ProjectUtil.updateProjectSDK()

--- a/src/main/kotlin/edu/kit/kastel/sdq/intelligrade/AssessmentTracker.kt
+++ b/src/main/kotlin/edu/kit/kastel/sdq/intelligrade/AssessmentTracker.kt
@@ -202,7 +202,7 @@ object AssessmentTracker {
         // Delete all directory contents, but not the directory itself
         val deletionQueue = mutableListOf<VirtualFile>()
         withContext(Dispatchers.IO) {
-            VfsUtil.visitChildrenRecursively(rootFile, object : VirtualFileVisitor<Void?>() {
+            VfsUtil.visitChildrenRecursively(rootFile, object : VirtualFileVisitor<Unit?>() {
                 override fun visitFile(file: VirtualFile): Boolean {
                     if (!file.isDirectory) {
                         deletionQueue.add(file)

--- a/src/main/kotlin/edu/kit/kastel/sdq/intelligrade/EndAssessmentService.kt
+++ b/src/main/kotlin/edu/kit/kastel/sdq/intelligrade/EndAssessmentService.kt
@@ -1,0 +1,94 @@
+package edu.kit.kastel.sdq.intelligrade
+
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.Project
+import com.intellij.platform.ide.progress.withBackgroundProgress
+import com.intellij.platform.util.progress.ProgressReporter
+import com.intellij.platform.util.progress.reportProgress
+import edu.kit.kastel.sdq.artemis4j.ArtemisNetworkException
+import edu.kit.kastel.sdq.artemis4j.grading.metajson.AnnotationMappingException
+import edu.kit.kastel.sdq.intelligrade.AssessmentTracker.cleanupAssessment
+import edu.kit.kastel.sdq.intelligrade.utils.ArtemisUtils
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+private val LOG = logger<EndAssessmentService>()
+
+enum class SubmitAction {
+    SUBMIT,
+    SAVE,
+    CANCEL,
+    CLOSE;
+
+    override fun toString(): String {
+        return when (this) {
+            SUBMIT -> "Submitting"
+            SAVE -> "Saving"
+            CANCEL -> "Cancelling"
+            CLOSE -> "Closing"
+        }
+    }
+}
+
+@Service(Service.Level.PROJECT)
+class EndAssessmentService(private val project: Project, private val cs: CoroutineScope) {
+    companion object {
+        @JvmStatic
+        fun getInstance(project: Project): EndAssessmentService {
+            return project.service<EndAssessmentService>()
+        }
+    }
+
+    fun queue(action: SubmitAction) {
+        // Launch the coroutine in the given scope with a progress indicator.
+        cs.launch {
+            withBackgroundProgress(project, "$action assessment") {
+                // A size of 100 = 100% progress
+                reportProgress(100) { reporter -> run(reporter, action) }
+            }
+        }
+    }
+
+    suspend fun run(reporter: ProgressReporter, action: SubmitAction) {
+        try {
+            // Update the assessment state in artemis:
+            reporter.sizedStep(50, "$action...") {
+                when (action) {
+                    SubmitAction.SUBMIT -> withContext(Dispatchers.IO) {
+                        AssessmentTracker.activeAssessment?.assessment?.submit()
+                    }
+                    SubmitAction.SAVE -> withContext(Dispatchers.IO) {
+                        AssessmentTracker.activeAssessment?.assessment?.save()
+                        ArtemisUtils.displayGenericInfoBalloon("Assessment saved", "The assessment has been saved.")
+                    }
+                    SubmitAction.CANCEL -> withContext(Dispatchers.IO) {
+                        AssessmentTracker.activeAssessment?.assessment?.cancel()
+                    }
+                    SubmitAction.CLOSE -> {
+                        // Closing the assessment does not require any action on the server side,
+                        // but we still want to clean up the local state.
+                        LOG.debug("Closing assessment without submitting or cancelling.")
+                    }
+                }
+            }
+
+            // Cleanup the assessment
+            reporter.sizedStep(50, "Cleaning...") {
+                cleanupAssessment()
+            }
+        } catch (e: ArtemisNetworkException) {
+            LOG.warn(e)
+            ArtemisUtils.displayNetworkErrorBalloon("Could not submit assessment", e)
+        } catch (e: AnnotationMappingException) {
+            LOG.warn(e)
+            ArtemisUtils.displayGenericErrorBalloon(
+                "Could not submit assessment",
+                "Failed to serialize the assessment. This is a serious bug; please contact the Übungsleitung!"
+            )
+        }
+    }
+}

--- a/src/main/kotlin/edu/kit/kastel/sdq/intelligrade/MavenProjectInitializer.kt
+++ b/src/main/kotlin/edu/kit/kastel/sdq/intelligrade/MavenProjectInitializer.kt
@@ -58,7 +58,7 @@ class MavenProjectInitializer(private val project: Project, private val cs: Coro
         //
         // Without this code, it will sometimes detect the maven project files, and sometimes not.
         cs.launch {
-            val root = ProjectUtil.getProjectRootVirtualFile(project);
+            val root = ProjectUtil.getProjectRootVirtualFile(project)
             if (root == null) {
                 LOG.error("Project root virtual file is null, cannot add maven project files")
                 return@launch

--- a/src/main/kotlin/edu/kit/kastel/sdq/intelligrade/MavenProjectInitializer.kt
+++ b/src/main/kotlin/edu/kit/kastel/sdq/intelligrade/MavenProjectInitializer.kt
@@ -1,0 +1,235 @@
+package edu.kit.kastel.sdq.intelligrade
+
+import com.intellij.openapi.application.EDT
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Pair
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.isFile
+import com.intellij.openapi.wm.ToolWindowManager
+import com.intellij.util.asDisposable
+import edu.kit.kastel.sdq.intelligrade.utils.ArtemisUtils
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.jetbrains.idea.maven.project.MavenProject
+import org.jetbrains.idea.maven.project.MavenProjectChanges
+import org.jetbrains.idea.maven.project.MavenProjectsManager
+import org.jetbrains.idea.maven.project.MavenProjectsTree
+import org.jetbrains.idea.maven.utils.actions.MavenActionUtil
+import org.jetbrains.idea.maven.wizards.MavenOpenProjectProvider
+
+private val LOG = logger<MavenProjectInitializer>()
+
+@Service(Service.Level.PROJECT)
+class MavenProjectInitializer(private val project: Project, private val cs: CoroutineScope) {
+    private val listeners: MutableList<suspend CoroutineScope.() -> Unit> = mutableListOf()
+    private var isInitialized = false
+    private var isResolved = false
+
+    companion object {
+        @JvmStatic
+        fun getInstance(project: Project): MavenProjectInitializer {
+            return project.service<MavenProjectInitializer>()
+        }
+    }
+
+    /**
+     * Registers a listener that will be called once when the project is initialized.
+     */
+    fun addListener(listener: suspend CoroutineScope.() -> Unit) {
+        listeners.add(listener)
+    }
+
+    fun isFinished(): Boolean {
+        return isInitialized && isResolved
+    }
+
+    fun start() {
+        isInitialized = false
+        isResolved = false
+
+        // It is important that intellij loads the maven project files, otherwise no files are visible
+        // in the project view.
+        //
+        // Without this code, it will sometimes detect the maven project files, and sometimes not.
+        cs.launch {
+            val root = ProjectUtil.getProjectRootVirtualFile(project);
+            if (root == null) {
+                LOG.error("Project root virtual file is null, cannot add maven project files")
+                return@launch
+            }
+
+            // This registers the files with maven, which should load the project correctly.
+            addMavenProjectFiles(project, root)
+        }
+
+        // The addMavenProjectFiles function has several problems:
+        // - the intellij code opens the maven tool window upon finishing loading
+        // -> the user would have to close it manually, which is annoying
+        // - the code runs asynchronously in the background -> can not execute code upon finishing the loading
+        // - some code relies on the maven project to be fully loaded (like setting the JDK, opening the main file, etc.)
+        //
+        // The below code makes sure that the maven tool window stays closed and that the listeners are called
+        // after the maven project is initialized.
+        cs.launch {
+            while (!isFinished()) {
+                delay(500) // Wait a bit before checking again
+
+                // This fetches the maven tool window (the window on the right side of the IDE with the maven logo)
+                val window = withContext(Dispatchers.EDT) {
+                    val manager = ToolWindowManager.getInstance(project)
+                    manager.getToolWindow("Maven")
+                }
+
+                if (window == null) {
+                    LOG.error("Maven tool window is missing")
+                    addMavenProjectFiles(project, ProjectUtil.getProjectRootVirtualFile(project) ?: return@launch)
+                    continue
+                }
+
+                if (window.isActive) {
+                    withContext(Dispatchers.EDT) {
+                        window.hide()
+                    }
+                }
+            }
+
+            // A huge problem is that I could not find a good way to wait for the maven project
+            // to be fully initialized.
+            //
+            // The intellij code is complicated, involves many classes and lots of things happening
+            // in the background. In addition to that, the code is almost completely without documentation,
+            // likely because it is not meant to be used by plugins.
+            //
+            // Intuitive things like `mavenManager.isMavenizedProject(project)` return true, even though the
+            // project is not fully initialized yet.
+            //
+            // As a stopgap solution, this timer exists, which should hopefully resolve some of the issues.
+            delay(2000) // Wait a bit to ensure everything is loaded
+
+            for (listener in listeners) {
+                listener()
+            }
+
+            // This class only has one instance, but the listeners are added in code that is called multiple times
+            // over the lifetime -> would cause duplicate listeners
+            //
+            // So we clear the listeners after they were called
+            listeners.clear()
+        }
+
+        // These two callbacks are called independently of each other, sometimes one is called when the other is not.
+        //
+        // A successfully loaded project will call both of them, which is why they are listened for here.
+        MavenProjectsManager.getInstance(project)
+            .addManagerListener(object : MavenProjectsManager.Listener {
+                override fun projectImportCompleted() {
+                    isInitialized = true
+                }
+            }, cs.asDisposable())
+
+        MavenProjectsManager.getInstance(project)
+            .addProjectsTreeListener(object: MavenProjectsTree.Listener {
+                override fun projectResolved(projectWithChanges: Pair<MavenProject, MavenProjectChanges>) {
+                    isResolved = true
+                }
+            })
+
+        cs.launch {
+            var counter = 0
+            while (!isFinished()) {
+                delay(1000) // Wait a second before checking to prevent busy-waiting
+
+                // in some cases the initialization with maven does not work, either isInitialized or isResolved
+                // will then be false.
+                if (isInitialized && !isResolved || !isInitialized && isResolved) {
+                    counter += 1
+
+                    if (counter == 5) {
+                        LOG.warn("Maven project initialization is not fully completed after 5 seconds. " +
+                                 "isInitialized: $isInitialized, isResolved: $isResolved")
+                        counter = 0
+
+                        // Try to force a new initialization of the maven project files:
+                        addMavenProjectFiles(project, ProjectUtil.getProjectRootVirtualFile(project) ?: return@launch)
+                    }
+                }
+
+                val window = withContext(Dispatchers.EDT) {
+                    val manager = ToolWindowManager.getInstance(project)
+                    manager.getToolWindow("Maven")
+                }
+
+                // If the maven window is missing, try to add the maven project files again.
+                if (window == null) {
+                    // Try to force a new initialization of the maven project files:
+                    addMavenProjectFiles(project, ProjectUtil.getProjectRootVirtualFile(project) ?: return@launch)
+                    continue
+                }
+
+                // This makes sure that the maven tool window is always closed. It sometimes opens automatically
+                // with the addMavenProjectFiles method, which is annoying.
+                //
+                // It sometimes opens after the project import callback is called, which is why it can not be
+                // done in a callback.
+                if (window.isActive) {
+                    withContext(Dispatchers.EDT) {
+                        window.hide()
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Registers the given project files to be managed by maven.
+     *
+     * This replicates the behavior of the "Add Maven project files" action, which calls
+     * the `AddManagedFilesAction`.
+     */
+    private suspend fun addMavenProjectFiles(project: Project, projectFile: VirtualFile) {
+        // Reset the state of the global variables that indicate whether the project is initialized or resolved.
+        isInitialized = false
+        isResolved = false
+
+        val manager = MavenProjectsManager.getInstance(project)
+
+        // The projectFile can be either a directory with the pom.xml (or equivalent) or the pom.xml file itself.
+        if (projectFile.isFile && (!MavenActionUtil.isMavenProjectFile(projectFile) || manager.isManagedFile(projectFile))) {
+            // If the given virtual file is a file that is
+            // - not a maven project file (e.g. not a pom.xml)
+            // - or is a maven project file but is already managed by maven
+            //
+            // then it is not a valid selection
+            LOG.error("The selected file is not a valid maven project file: ${projectFile.presentableUrl}")
+            return
+        }
+
+        val selectedFiles = if (projectFile.isDirectory) projectFile.children else arrayOf(projectFile)
+        if (!selectedFiles.any { MavenActionUtil.isMavenProjectFile(it) }) {
+            ArtemisUtils.displayGenericErrorBalloon(
+                "Failed to find Maven project files",
+                "No project files found in ${projectFile.presentableUrl}"
+            )
+            return
+        }
+
+        // The given method is marked as internal.
+        //
+        // This is not ideal, but a lot of other code like
+        //
+        // manager.addManagedFiles(listOf(pomFile))
+        // manager.updateAllMavenProjects(MavenSyncSpec.incremental("MavenProjectInitializer", false))
+        //
+        // has been tried. Some of them work, but they are a lot less reliable that the one below.
+        // There might be a better way to do this, but because this is the method called by the action
+        // it seems like the obvious choice.
+        val openProjectProvider = MavenOpenProjectProvider()
+        openProjectProvider.forceLinkToExistingProjectAsync(projectFile, project)
+    }
+}

--- a/src/main/kotlin/edu/kit/kastel/sdq/intelligrade/ProjectUtil.kt
+++ b/src/main/kotlin/edu/kit/kastel/sdq/intelligrade/ProjectUtil.kt
@@ -1,0 +1,104 @@
+package edu.kit.kastel.sdq.intelligrade
+
+import com.intellij.openapi.application.writeAction
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.projectRoots.ProjectJdkTable
+import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.openapi.roots.ProjectRootManager
+import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.newvfs.RefreshQueue
+import com.intellij.util.lang.JavaVersion
+import edu.kit.kastel.sdq.intelligrade.utils.IntellijUtil
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.nio.file.Path
+import java.util.function.Function
+
+private val LOG = logger<ProjectUtil>()
+
+object ProjectUtil {
+    suspend fun getProjectRootVirtualFile(project: Project): VirtualFile? {
+        val rootDirectory = Path.of(project.basePath!!)
+
+        return withContext(Dispatchers.IO) {
+            VfsUtil.findFile(rootDirectory, true)
+        }
+    }
+
+    suspend fun forceFilesSync() = coroutineScope {
+        val rootVirtualFile = withContext(Dispatchers.IO) {
+            VfsUtil.findFileByIoFile(IntellijUtil.getProjectRootDirectory().toFile(), true)
+        }
+        if (rootVirtualFile == null) {
+            LOG.warn("Root virtual file is null, cannot force files sync")
+            return@coroutineScope
+        }
+
+        launch {
+            withContext(Dispatchers.IO) {
+                // This is necessary to ensure that the file system is up-to-date before we start the sync
+                VfsUtil.markDirtyAndRefresh(false, true, true, rootVirtualFile)
+            }
+        }
+
+        launch {
+            withContext(Dispatchers.IO) {
+                rootVirtualFile.refresh(false, true)
+            }
+        }
+    }
+
+
+    /**
+     * Checks if the active project has a JDK set and if not, it will set a JDK.
+     */
+    suspend fun updateProjectSDK() {
+        // It is amazing how much is possible, the difficult part is finding the right classes
+        // that do what you want... this was much more work than it looks like.
+        val manager = ProjectRootManager.getInstance(IntellijUtil.getActiveProject())
+
+        // check if SDK is already set
+        val projectSdk = manager.projectSdk
+        if (projectSdk != null) {
+            LOG.debug("SDK already set: " + projectSdk.versionString)
+            return
+        }
+
+        // if not, set the SDK.
+        val jdkTable = ProjectJdkTable.getInstance()
+
+        val javaSdkTypeId = jdkTable.getSdkTypeByName(IntellijUtil.JAVA_SDK_TYPE_NAME)
+
+        val availableSdks = ProjectJdkTable.getInstance().getSdksOfType(javaSdkTypeId)
+        if (availableSdks.isEmpty()) {
+            LOG.warn("No SDK found, please install a JDK")
+            return
+        }
+
+        // they are sorted starting from the latest version
+        val sortedSdks = availableSdks.stream()
+            .filter { sdk: Sdk? -> sdk!!.versionString != null && JavaVersion.tryParse(sdk.versionString) != null }
+            .sorted(Comparator.comparing(Function { sdk: Sdk? -> JavaVersion.parse(sdk!!.versionString!!) }))
+            .toList()
+
+        LOG.debug("Available SDKs: $sortedSdks")
+        for (availableSdk in availableSdks) {
+            if (availableSdk.versionString == null) {
+                continue
+            }
+
+            if (JavaVersion.parse(availableSdk.versionString!!).isAtLeast(IntellijUtil.TARGET_SDK_VERSION)) {
+                // update the project sdk, this has to be done in a dedicated thread to prevent crashes
+
+                writeAction { manager.projectSdk = availableSdk }
+                return
+            }
+        }
+
+        LOG.error("No suitable SDK found, please install a JDK with version " + IntellijUtil.TARGET_SDK_VERSION + " or higher")
+    }
+}

--- a/src/main/kotlin/edu/kit/kastel/sdq/intelligrade/ProjectUtil.kt
+++ b/src/main/kotlin/edu/kit/kastel/sdq/intelligrade/ProjectUtil.kt
@@ -8,7 +8,6 @@ import com.intellij.openapi.projectRoots.Sdk
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.openapi.vfs.newvfs.RefreshQueue
 import com.intellij.util.lang.JavaVersion
 import edu.kit.kastel.sdq.intelligrade.utils.IntellijUtil
 import kotlinx.coroutines.Dispatchers

--- a/src/main/kotlin/edu/kit/kastel/sdq/intelligrade/ReopenAssessmentService.kt
+++ b/src/main/kotlin/edu/kit/kastel/sdq/intelligrade/ReopenAssessmentService.kt
@@ -1,0 +1,78 @@
+package edu.kit.kastel.sdq.intelligrade
+
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.platform.ide.progress.withModalProgress
+import com.intellij.platform.util.progress.ProgressReporter
+import com.intellij.platform.util.progress.reportProgress
+import edu.kit.kastel.sdq.artemis4j.ArtemisNetworkException
+import edu.kit.kastel.sdq.artemis4j.grading.MoreRecentSubmissionException
+import edu.kit.kastel.sdq.artemis4j.grading.ProgrammingSubmission
+import edu.kit.kastel.sdq.artemis4j.grading.metajson.AnnotationMappingException
+import edu.kit.kastel.sdq.artemis4j.grading.penalty.GradingConfig
+import edu.kit.kastel.sdq.intelligrade.utils.ArtemisUtils
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+private val LOG = logger<ReopenAssessmentService>()
+
+@Service(Service.Level.PROJECT)
+class ReopenAssessmentService(private val project: Project, private val cs: CoroutineScope) {
+    companion object {
+        @JvmStatic
+        fun getInstance(project: Project): ReopenAssessmentService {
+            return project.service<ReopenAssessmentService>()
+        }
+    }
+
+    fun queue(submission: ProgrammingSubmission, gradingConfig: GradingConfig) {
+        // Launch the coroutine in the given scope with a progress indicator.
+        // modal = progress is in the foreground and not in the right bottom corner
+        cs.launch {
+            withModalProgress(project, "Reopening assessment") {
+                // A size of 100 = 100% progress
+                reportProgress(100) { reporter -> run(reporter, submission, gradingConfig) }
+            }
+        }
+    }
+
+    suspend fun run(reporter: ProgressReporter, submission: ProgrammingSubmission, gradingConfig: GradingConfig) {
+        try {
+            val assessment = reporter.sizedStep(20, "Locking...") {
+                withContext(Dispatchers.IO) {
+                    submission.tryLock(gradingConfig)
+                }
+            }
+
+            if (assessment.isEmpty) {
+                ArtemisUtils.displayGenericErrorBalloon(
+                    "Failed to reopen assessment", "Most likely, your lock has been taken by someone else."
+                )
+                return
+            }
+
+            reporter.sizedStep(80, "Cloning...") {
+                AssessmentTracker.initializeAssessment(assessment.get())
+            }
+        } catch (e: ArtemisNetworkException) {
+            LOG.warn(e)
+            ArtemisUtils.displayNetworkErrorBalloon("Could not lock assessment", e)
+        } catch (e: AnnotationMappingException) {
+            LOG.warn(e)
+            ArtemisUtils.displayGenericErrorBalloon(
+                "Could not parse assessment",
+                "Could not parse previous assessment. This is a serious bug; please contact the "
+                        + "Übungsleitung!"
+            )
+        } catch (e: MoreRecentSubmissionException) {
+            LOG.warn(e)
+            ArtemisUtils.displayGenericErrorBalloon(
+                "Could not reopen assessment", "The student has submitted a newer version of his code."
+            )
+        }
+    }
+}

--- a/src/main/kotlin/edu/kit/kastel/sdq/intelligrade/StartAssessmentService.kt
+++ b/src/main/kotlin/edu/kit/kastel/sdq/intelligrade/StartAssessmentService.kt
@@ -1,0 +1,93 @@
+package edu.kit.kastel.sdq.intelligrade
+
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.Project
+import com.intellij.platform.ide.progress.withModalProgress
+import com.intellij.platform.util.progress.ProgressReporter
+import com.intellij.platform.util.progress.reportProgress
+import edu.kit.kastel.sdq.artemis4j.ArtemisNetworkException
+import edu.kit.kastel.sdq.artemis4j.grading.ProgrammingExercise
+import edu.kit.kastel.sdq.artemis4j.grading.metajson.AnnotationMappingException
+import edu.kit.kastel.sdq.artemis4j.grading.penalty.GradingConfig
+import edu.kit.kastel.sdq.intelligrade.extensions.guis.SplashDialog
+import edu.kit.kastel.sdq.intelligrade.utils.ArtemisUtils
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+private val LOG = logger<StartAssessmentService>()
+
+@Service(Service.Level.PROJECT)
+class StartAssessmentService(private val project: Project, private val cs: CoroutineScope) {
+    companion object {
+        @JvmStatic
+        fun getInstance(project: Project): StartAssessmentService {
+            return project.service<StartAssessmentService>()
+        }
+    }
+
+    fun queue(correctionRound: Int, gradingConfig: GradingConfig, activeExercise: ProgrammingExercise) {
+        // Launch the coroutine in the given scope with a progress indicator.
+        // modal = progress is in the foreground and not in the right bottom corner
+        cs.launch {
+            withModalProgress(project, "Starting assessment") {
+                // A size of 100 = 100% progress
+                reportProgress(100) { reporter -> run(reporter, correctionRound, gradingConfig, activeExercise) }
+            }
+        }
+    }
+
+    suspend fun run(reporter: ProgressReporter, correctionRound: Int, gradingConfig: GradingConfig, activeExercise: ProgrammingExercise) {
+        try {
+            val nextAssessment = reporter.sizedStep(20, "Locking...") {
+                activeExercise.tryLockNextSubmission(correctionRound, gradingConfig)
+            }
+
+            if (nextAssessment.isEmpty) {
+                ArtemisUtils.displayGenericInfoBalloon(
+                    "Could not start assessment",
+                    "There are no more submissions to assess. Thanks for your work :)"
+                )
+
+                return
+            }
+
+            val activeAssessment = reporter.sizedStep(80, "Cloning...") {
+                AssessmentTracker.initializeAssessment(nextAssessment.get())
+            }
+
+            if (activeAssessment == null) {
+                return
+            }
+
+            SplashDialog.showMaybe()
+
+            // Now everything is done - the submission is properly locked, and the repository is cloned
+            if (activeAssessment.assessment.annotations.isEmpty()) {
+                activeAssessment.runAutograder()
+            } else {
+                ArtemisUtils.displayGenericInfoBalloon(
+                    "Skipping Autograder",
+                    "The submission already has annotations. Skipping the Autograder."
+                )
+            }
+
+            ArtemisUtils.displayGenericInfoBalloon(
+                "Assessment started",
+                "You can now grade the submission. Please make sure that are familiar with all "
+                        + "grading guidelines."
+            )
+        } catch (e: ArtemisNetworkException) {
+            LOG.warn(e)
+            ArtemisUtils.displayNetworkErrorBalloon("Could not lock assessment", e)
+        } catch (e: AnnotationMappingException) {
+            LOG.warn(e)
+            ArtemisUtils.displayGenericErrorBalloon(
+                "Could not parse assessment",
+                "Could not parse previous assessment. This is a serious bug; please contact the "
+                        + "Übungsleitung!"
+            )
+        }
+    }
+}

--- a/src/main/kotlin/edu/kit/kastel/sdq/intelligrade/StartAssessmentService.kt
+++ b/src/main/kotlin/edu/kit/kastel/sdq/intelligrade/StartAssessmentService.kt
@@ -75,7 +75,7 @@ class StartAssessmentService(private val project: Project, private val cs: Corou
 
             ArtemisUtils.displayGenericInfoBalloon(
                 "Assessment started",
-                "You can now grade the submission. Please make sure that are familiar with all "
+                "You can now grade the submission. Please make sure you are familiar with all "
                         + "grading guidelines."
             )
         } catch (e: ArtemisNetworkException) {


### PR DESCRIPTION
This PR...
- closes #129 
- closes #132 (the `AutograderTask` is still written in Java, but that shouldn't be an issue)
- closes #116

This PR doesn't add things that are visible to the user, instead it should help with making intelligrade more reliable.

The current master is frequently crashing on Windows, because of https://github.com/eclipse-jgit/jgit/issues/155. It happens relatively frequently that the project is not loaded, resulting in only a few files being visible:
![image](https://github.com/user-attachments/assets/1c19de3a-16a3-4b08-9896-88fa45f4eb9b)
and often the SDK is not set.

This PR eliminates most of these pain points. One thing that does not work every time is the project loading. I spent a lot of time investigating this, many things have been tried, and I am running out of ideas on what to do.

Therefore, I am submitting this PR as is, and in the future I might revisit the problem again.

There are some new exceptions in the console, like this one
```
java.nio.file.InvalidPathException: Watch roots should be absolute: ${project.basedir}/test
	at com.intellij.openapi.vfs.impl.local.WatchRootsManager.prepareWatchRoot(WatchRootsManager.java:233)
	at com.intellij.openapi.vfs.impl.local.WatchRootsManager.updateWatchRoots(WatchRootsManager.java:184)
	at com.intellij.openapi.vfs.impl.local.WatchRootsManager.replaceWatchedRoots(WatchRootsManager.java:74)
	at com.intellij.openapi.vfs.impl.local.LocalFileSystemImpl.replaceWatchedRoots(LocalFileSystemImpl.java:201)
	at com.intellij.openapi.roots.impl.ProjectRootManagerComponent.postCollect(ProjectRootManagerComponent.kt:230)
	at com.intellij.openapi.roots.impl.ProjectRootManagerComponent.access$postCollect(ProjectRootManagerComponent.kt:68)
	at com.intellij.openapi.roots.impl.ProjectRootManagerComponent$addRootsToWatch$2$job$1.invokeSuspend(ProjectRootManagerComponent.kt:215)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
```
or this one
```
com.intellij.execution.ExecutionException: 
	at com.intellij.execution.rmi.RemoteProcessSupport.acquire(RemoteProcessSupport.java:200)
	at org.jetbrains.idea.maven.server.MavenServerConnectorImpl$StartServerTask$run$2.invokeSuspend(MavenServerConnectorImpl.kt:91)
	at org.jetbrains.idea.maven.server.MavenServerConnectorImpl$StartServerTask$run$2.invoke(MavenServerConnectorImpl.kt)
	at org.jetbrains.idea.maven.server.MavenServerConnectorImpl$StartServerTask$run$2.invoke(MavenServerConnectorImpl.kt)
```

I have absolutely no idea what to do about them, so I am ignoring them for now.