### PR TITLE
Resolve some crashes and add debug window for annotations

### DIFF
--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/guis/AnnotationsListPanel.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/guis/AnnotationsListPanel.java
@@ -1,25 +1,34 @@
 /* Licensed under EPL-2.0 2024-2025. */
 package edu.kit.kastel.sdq.intelligrade.extensions.guis;
 
+import java.awt.EventQueue;
+import java.awt.event.InputEvent;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
+import javax.swing.JButton;
 import javax.swing.tree.TreePath;
 
 import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.DefaultActionGroup;
 import com.intellij.openapi.ui.SimpleToolWindowPanel;
+import com.intellij.openapi.ui.popup.JBPopupFactory;
 import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.ui.AnActionButton;
 import com.intellij.ui.PopupHandler;
 import com.intellij.ui.ScrollPaneFactory;
+import com.intellij.ui.components.JBLabel;
+import com.intellij.ui.components.JBPanel;
+import com.intellij.ui.components.JBTextField;
 import edu.kit.kastel.sdq.artemis4j.grading.Annotation;
 import edu.kit.kastel.sdq.intelligrade.extensions.guis.table.AnnotationsTableModel;
 import edu.kit.kastel.sdq.intelligrade.extensions.guis.table.AnnotationsTreeTable;
 import edu.kit.kastel.sdq.intelligrade.state.PluginState;
 import edu.kit.kastel.sdq.intelligrade.utils.IntellijUtil;
+import net.miginfocom.swing.MigLayout;
 import org.jetbrains.annotations.NotNull;
 
 public class AnnotationsListPanel extends SimpleToolWindowPanel {
@@ -98,6 +107,75 @@ public class AnnotationsListPanel extends SimpleToolWindowPanel {
         };
         group.addAction(deleteButton);
 
+        // Adds a debug button to the right-click menu in the table.
+        //
+        // There is some data regarding the annotations that is not visible in the table,
+        // like what exact location the annotation refers to or which problem type in the autograder
+        // emitted the annotation.
+        var debugButton = new AnActionButton("Debug Information") {
+            @Override
+            public void actionPerformed(@NotNull AnActionEvent e) {
+                var annotations = table.getSelectedAnnotations();
+                if (annotations.isEmpty()) {
+                    return;
+                }
+
+                // we only emit information about the first selected annotation
+                var annotation = annotations.getFirst();
+                showDebugDialog(annotation);
+            }
+
+            @Override
+            public @NotNull ActionUpdateThread getActionUpdateThread() {
+                return ActionUpdateThread.EDT;
+            }
+        };
+        group.addAction(debugButton);
+
         PopupHandler.installPopupMenu(table, group, "popup@AnnotationsListPanel");
+    }
+
+    private void showDebugDialog(Annotation annotation) {
+        var panel = new JBPanel<>(new MigLayout("wrap 2", "[] [grow]"));
+
+        var location = annotation.getLocation();
+
+        // This is a list instead of a map, so that the order of the entries is stable.
+        var data = List.of(
+                Map.entry("UUID", annotation.getUUID()),
+                Map.entry("MistakeType", annotation.getMistakeType().getId()),
+                Map.entry(
+                        "RatingGroup",
+                        annotation.getMistakeType().getRatingGroup().getId()),
+                Map.entry("Path", location.filePath()),
+                Map.entry("Start", location.start().toString()),
+                Map.entry("End", location.end().toString()),
+                Map.entry("Classifiers", annotation.getClassifiers().toString()));
+
+        for (var entry : data) {
+            panel.add(new JBLabel(entry.getKey()));
+            // Uses a text field here, because one can not select/copy text from a label.
+            var field = new JBTextField(entry.getValue());
+            field.setEditable(false);
+            panel.add(field, "growx");
+        }
+
+        var okButton = new JButton("Ok");
+        panel.add(okButton, "skip 1, tag ok");
+
+        var popup = JBPopupFactory.getInstance()
+                .createComponentPopupBuilder(ScrollPaneFactory.createScrollPane(panel), panel)
+                .setTitle("Debug Information")
+                .setFocusable(true)
+                .setRequestFocus(true)
+                .setMovable(true)
+                .setResizable(true)
+                .setCancelOnClickOutside(false)
+                .setNormalWindowLevel(true)
+                .createPopup();
+
+        okButton.addActionListener(a -> popup.closeOk((InputEvent) EventQueue.getCurrentEvent()));
+
+        popup.showCenteredInCurrentWindow(IntellijUtil.getActiveProject());
     }
 }

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/guis/ExercisePanel.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/guis/ExercisePanel.java
@@ -391,7 +391,10 @@ public class ExercisePanel extends SimpleToolWindowPanel {
 
     private void handleAssessmentClosed() {
         startGradingRound1Button.setEnabled(true);
-        startGradingRound2Button.setEnabled(exerciseSelector.getItem().hasSecondCorrectionRound());
+        // If no exercise is selected (e.g. not connected to artemis), the getItem() will return null.
+        if (exerciseSelector.getItem() != null) {
+            startGradingRound2Button.setEnabled(exerciseSelector.getItem().hasSecondCorrectionRound());
+        }
 
         assessmentPanel.setEnabled(false);
         submitAssessmentButton.setEnabled(false);

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/guis/table/AnnotationsTreeTable.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/guis/table/AnnotationsTreeTable.java
@@ -261,20 +261,23 @@ public class AnnotationsTreeTable extends TreeTable {
                 .changeCustomMessage(annotationNode.getAnnotation());
     }
 
-    public void deleteSelection() {
+    public List<Annotation> getSelectedAnnotations() {
         TreePath[] paths = getTree().getSelectionPaths();
         if (paths == null || paths.length == 0) {
-            return;
+            return List.of();
         }
 
-        // First collect all annotations to delete, then delete them
-        // If delete them one by one, the row indices change and the wrong annotations are deleted
-        var annotationsToDelete = Arrays.stream(paths)
+        // Collect all annotations from the selected paths
+        return Arrays.stream(paths)
                 .map(TreePath::getLastPathComponent)
                 .map(AnnotationsTreeNode.class::cast)
                 .map(AnnotationsTreeNode::listAnnotations)
                 .flatMap(List::stream)
                 .toList();
+    }
+
+    public void deleteSelection() {
+        List<Annotation> annotationsToDelete = getSelectedAnnotations();
 
         LOG.debug("Deleting annotations: " + annotationsToDelete);
         var assessment = PluginState.getInstance().getActiveAssessment().orElseThrow();

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/state/PluginState.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/state/PluginState.java
@@ -57,15 +57,16 @@ public class PluginState {
         AssessmentTracker.INSTANCE.addListener(changedAssessment -> {
             activeAssessment = changedAssessment;
 
+            // The invokeLater ensures that the listeners are running on EDT, which is required for UI updates.
             if (changedAssessment == null) {
                 // Notify listeners that the assessment was closed
                 for (Runnable listener : assessmentClosedListeners) {
-                    listener.run();
+                    ApplicationManager.getApplication().invokeLater(listener);
                 }
             } else {
                 // Notify listeners that the assessment was started
                 for (Consumer<ActiveAssessment> listener : assessmentStartedListeners) {
-                    listener.accept(changedAssessment);
+                    ApplicationManager.getApplication().invokeLater(() -> listener.accept(changedAssessment));
                 }
             }
         });

--- a/src/main/kotlin/edu/kit/kastel/sdq/intelligrade/AssessmentTracker.kt
+++ b/src/main/kotlin/edu/kit/kastel/sdq/intelligrade/AssessmentTracker.kt
@@ -43,6 +43,14 @@ object AssessmentTracker {
     var activeAssessment: ActiveAssessment? = null
     private val listeners: MutableList<AssessmentListener> = mutableListOf()
 
+    /**
+     * Adds a listener that will be notified when the active assessment changes.
+     *
+     * This can be when a new assessment is started or when the current assessment is cleared.
+     *
+     * Regarding Threading Model: There is no guarantee that the listener will be called on EDT,
+     * make sure to account for that.
+     */
     fun addListener(listener: AssessmentListener) {
         listeners.add(listener)
     }
@@ -68,7 +76,7 @@ object AssessmentTracker {
     }
 
     @Throws(ArtemisClientException::class)
-    suspend fun cloneSubmission(workspacePath: Path?, assessment: Assessment): ClonedProgrammingSubmission? {
+    private suspend fun cloneSubmission(workspacePath: Path?, assessment: Assessment): ClonedProgrammingSubmission? {
         // Clone the new submission
         val submission = when (ArtemisSettingsState.getInstance().vcsAccessOption) {
             VCSAccessOption.SSH -> withContext(Dispatchers.IO) {

--- a/src/main/kotlin/edu/kit/kastel/sdq/intelligrade/MavenProjectInitializer.kt
+++ b/src/main/kotlin/edu/kit/kastel/sdq/intelligrade/MavenProjectInitializer.kt
@@ -93,7 +93,7 @@ class MavenProjectInitializer(private val project: Project, private val cs: Coro
         return cs.launch {
             val root = ProjectUtil.getProjectRootVirtualFile(project)
             if (root == null) {
-                LOG.error("Project root virtual file is null, cannot add maven project files")
+                LOG.warn("Project root virtual file is null, cannot add maven project files")
                 return@launch
             }
 
@@ -122,7 +122,7 @@ class MavenProjectInitializer(private val project: Project, private val cs: Coro
         }
 
         if (window == null) {
-            LOG.error("Maven tool window is missing")
+            LOG.warn("Maven tool window is missing")
             addMavenProjectFiles(project, projectRoot)
             return
         }
@@ -233,7 +233,7 @@ class MavenProjectInitializer(private val project: Project, private val cs: Coro
             // - or is a maven project file but is already managed by maven
             //
             // then it is not a valid selection
-            LOG.error("The selected file is not a valid maven project file: ${projectFile.presentableUrl}")
+            LOG.warn("The selected file is not a valid maven project file: ${projectFile.presentableUrl}")
             return
         }
 


### PR DESCRIPTION
There were some minor oversights that I did not observe when testing #133.

In addition to that, this PR adds a new context menu option to show more data for annotations:
![image](https://github.com/user-attachments/assets/308461d9-083f-4db8-a880-90db5bd5b389)
![image](https://github.com/user-attachments/assets/fcf99bdd-ca3a-4387-aef1-4859adfdec02)

This will help with figuring out problems related to how annotations are displayed/their locations and one can easily see which autograder class produced a certain annotation.