### PR TITLE
Replace Jetbrains annotations with JSpecify

### DIFF
--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/actions/AddAnnotationPopupAction.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/actions/AddAnnotationPopupAction.java
@@ -22,18 +22,18 @@ import com.intellij.ui.popup.list.ListPopupImpl;
 import edu.kit.kastel.sdq.artemis4j.grading.penalty.MistakeType;
 import edu.kit.kastel.sdq.intelligrade.state.PluginState;
 import edu.kit.kastel.sdq.intelligrade.utils.ArtemisUtils;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 public class AddAnnotationPopupAction extends AnAction {
     private static final Locale LOCALE = DynamicBundle.getLocale();
 
     @Override
-    public @NotNull ActionUpdateThread getActionUpdateThread() {
+    public @NonNull ActionUpdateThread getActionUpdateThread() {
         return ActionUpdateThread.BGT;
     }
 
     @Override
-    public void update(@NotNull AnActionEvent e) {
+    public void update(@NonNull AnActionEvent e) {
         Caret caret = e.getData(CommonDataKeys.CARET);
 
         // if no exercise config is loaded, we cannot make annotations
@@ -43,7 +43,7 @@ public class AddAnnotationPopupAction extends AnAction {
     }
 
     @Override
-    public void actionPerformed(@NotNull AnActionEvent e) {
+    public void actionPerformed(@NonNull AnActionEvent e) {
         Caret caret = e.getData(CommonDataKeys.CARET);
 
         // if no exercise config is loaded, we cannot make annotations
@@ -107,7 +107,7 @@ public class AddAnnotationPopupAction extends AnAction {
         }
 
         @Override
-        public void actionPerformed(@NotNull AnActionEvent e) {
+        public void actionPerformed(@NonNull AnActionEvent e) {
             boolean withCustomMessage =
                     e.getInputEvent() != null && e.getInputEvent().isControlDown();
             PluginState.getInstance()
@@ -117,7 +117,7 @@ public class AddAnnotationPopupAction extends AnAction {
         }
 
         @Override
-        public @NotNull ActionUpdateThread getActionUpdateThread() {
+        public @NonNull ActionUpdateThread getActionUpdateThread() {
             return ActionUpdateThread.EDT;
         }
 

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/autograder/AutograderTask.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/autograder/AutograderTask.java
@@ -1,4 +1,4 @@
-/* Licensed under EPL-2.0 2024. */
+/* Licensed under EPL-2.0 2024-2025. */
 package edu.kit.kastel.sdq.intelligrade.autograder;
 
 import java.io.IOException;
@@ -21,7 +21,7 @@ import edu.kit.kastel.sdq.intelligrade.extensions.settings.ArtemisSettingsState;
 import edu.kit.kastel.sdq.intelligrade.extensions.settings.AutograderOption;
 import edu.kit.kastel.sdq.intelligrade.utils.ArtemisUtils;
 import edu.kit.kastel.sdq.intelligrade.utils.IntellijUtil;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 public class AutograderTask extends Task.Backgroundable {
     private static final Logger LOG = Logger.getInstance(AutograderTask.class);
@@ -45,7 +45,7 @@ public class AutograderTask extends Task.Backgroundable {
         this.onSuccessCallback = onSuccess;
     }
 
-    public void run(@NotNull ProgressIndicator indicator) {
+    public void run(@NonNull ProgressIndicator indicator) {
         indicator.setIndeterminate(true);
 
         var settings = ArtemisSettingsState.getInstance();

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/guis/AnnotationsListPanel.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/guis/AnnotationsListPanel.java
@@ -29,7 +29,7 @@ import edu.kit.kastel.sdq.intelligrade.extensions.guis.table.AnnotationsTreeTabl
 import edu.kit.kastel.sdq.intelligrade.state.PluginState;
 import edu.kit.kastel.sdq.intelligrade.utils.IntellijUtil;
 import net.miginfocom.swing.MigLayout;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 public class AnnotationsListPanel extends SimpleToolWindowPanel {
     private final AnnotationsTableModel model;
@@ -83,12 +83,12 @@ public class AnnotationsListPanel extends SimpleToolWindowPanel {
 
         var editButton = new AnActionButton("Edit Custom Message/Score") {
             @Override
-            public void actionPerformed(@NotNull AnActionEvent e) {
+            public void actionPerformed(@NonNull AnActionEvent e) {
                 table.editCustomMessageOfSelection();
             }
 
             @Override
-            public @NotNull ActionUpdateThread getActionUpdateThread() {
+            public @NonNull ActionUpdateThread getActionUpdateThread() {
                 return ActionUpdateThread.EDT;
             }
         };
@@ -96,12 +96,12 @@ public class AnnotationsListPanel extends SimpleToolWindowPanel {
 
         var deleteButton = new AnActionButton("Delete") {
             @Override
-            public void actionPerformed(@NotNull AnActionEvent e) {
+            public void actionPerformed(@NonNull AnActionEvent e) {
                 table.deleteSelection();
             }
 
             @Override
-            public @NotNull ActionUpdateThread getActionUpdateThread() {
+            public @NonNull ActionUpdateThread getActionUpdateThread() {
                 return ActionUpdateThread.EDT;
             }
         };
@@ -109,12 +109,12 @@ public class AnnotationsListPanel extends SimpleToolWindowPanel {
 
         var restoreButton = new AnActionButton("Restore") {
             @Override
-            public void actionPerformed(@NotNull AnActionEvent e) {
+            public void actionPerformed(@NonNull AnActionEvent e) {
                 table.restoreSelection();
             }
 
             @Override
-            public @NotNull ActionUpdateThread getActionUpdateThread() {
+            public @NonNull ActionUpdateThread getActionUpdateThread() {
                 return ActionUpdateThread.EDT;
             }
         };
@@ -129,7 +129,7 @@ public class AnnotationsListPanel extends SimpleToolWindowPanel {
         // emitted the annotation.
         var debugButton = new AnActionButton("Debug Information") {
             @Override
-            public void actionPerformed(@NotNull AnActionEvent e) {
+            public void actionPerformed(@NonNull AnActionEvent e) {
                 var annotations = table.getSelectedAnnotations();
                 if (annotations.isEmpty()) {
                     return;
@@ -141,7 +141,7 @@ public class AnnotationsListPanel extends SimpleToolWindowPanel {
             }
 
             @Override
-            public @NotNull ActionUpdateThread getActionUpdateThread() {
+            public @NonNull ActionUpdateThread getActionUpdateThread() {
                 return ActionUpdateThread.EDT;
             }
         };

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/guis/BacklogPanel.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/guis/BacklogPanel.java
@@ -24,7 +24,7 @@ import edu.kit.kastel.sdq.artemis4j.grading.PackedAssessment;
 import edu.kit.kastel.sdq.intelligrade.state.PluginState;
 import edu.kit.kastel.sdq.intelligrade.utils.ArtemisUtils;
 import net.miginfocom.swing.MigLayout;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 public class BacklogPanel extends JPanel {
     private final SearchTextField searchField;
@@ -50,7 +50,7 @@ public class BacklogPanel extends JPanel {
         filterPanel.add(searchField, "growx");
         searchField.addDocumentListener(new DocumentAdapter() {
             @Override
-            protected void textChanged(@NotNull DocumentEvent documentEvent) {
+            protected void textChanged(@NonNull DocumentEvent documentEvent) {
                 updateBacklog();
             }
         });

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/guis/ExercisePanel.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/guis/ExercisePanel.java
@@ -45,7 +45,7 @@ import edu.kit.kastel.sdq.intelligrade.state.PluginState;
 import edu.kit.kastel.sdq.intelligrade.utils.ArtemisUtils;
 import edu.kit.kastel.sdq.intelligrade.utils.IntellijUtil;
 import net.miginfocom.swing.MigLayout;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 public class ExercisePanel extends SimpleToolWindowPanel {
     private static final Logger LOG = Logger.getInstance(ExercisePanel.class);
@@ -171,7 +171,7 @@ public class ExercisePanel extends SimpleToolWindowPanel {
         gradingConfigPathInput.setText(ArtemisSettingsState.getInstance().getSelectedGradingConfigPath());
         gradingConfigPathInput.getTextField().getDocument().addDocumentListener(new DocumentAdapter() {
             @Override
-            protected void textChanged(@NotNull DocumentEvent documentEvent) {
+            protected void textChanged(@NonNull DocumentEvent documentEvent) {
                 PluginState.getInstance().setSelectedGradingConfigPath(gradingConfigPathInput.getText());
 
                 // When nothing is selected, the border is red. This code is called when something has been selected

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/guis/SplashDialog.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/guis/SplashDialog.java
@@ -1,4 +1,4 @@
-/* Licensed under EPL-2.0 2024. */
+/* Licensed under EPL-2.0 2024-2025. */
 package edu.kit.kastel.sdq.intelligrade.extensions.guis;
 
 import java.time.Duration;
@@ -21,8 +21,8 @@ import com.intellij.ui.dsl.builder.components.DslLabelType;
 import com.intellij.util.ui.JBFont;
 import edu.kit.kastel.sdq.intelligrade.utils.IntellijUtil;
 import net.miginfocom.swing.MigLayout;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 public class SplashDialog extends DialogWrapper {
     private static final TemporalAmount SPLASH_INTERVAL = Duration.ofMinutes(60);
@@ -71,7 +71,7 @@ public class SplashDialog extends DialogWrapper {
     }
 
     @Override
-    protected Action @NotNull [] createActions() {
+    protected Action @NonNull [] createActions() {
         return new Action[] {this.myOKAction};
     }
 

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/guis/SubmissionsInstructorDialog.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/guis/SubmissionsInstructorDialog.java
@@ -35,8 +35,8 @@ import edu.kit.kastel.sdq.intelligrade.state.PluginState;
 import edu.kit.kastel.sdq.intelligrade.utils.ArtemisUtils;
 import net.miginfocom.swing.MigLayout;
 import org.jetbrains.annotations.Nls;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 public class SubmissionsInstructorDialog extends DialogWrapper {
     private static final Logger LOG = Logger.getInstance(SubmissionsInstructorDialog.class);
@@ -74,7 +74,7 @@ public class SubmissionsInstructorDialog extends DialogWrapper {
         searchPanel.add(searchField, "growx");
         searchField.addDocumentListener(new DocumentAdapter() {
             @Override
-            protected void textChanged(@NotNull DocumentEvent documentEvent) {
+            protected void textChanged(@NonNull DocumentEvent documentEvent) {
                 updateShownSubmissions();
             }
         });
@@ -106,7 +106,7 @@ public class SubmissionsInstructorDialog extends DialogWrapper {
     }
 
     @Override
-    protected Action @NotNull [] createActions() {
+    protected Action @NonNull [] createActions() {
         return new Action[] {this.myCancelAction};
     }
 

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/guis/table/AnnotationsTreeNode.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/guis/table/AnnotationsTreeNode.java
@@ -23,7 +23,7 @@ import com.intellij.ui.treeStructure.treetable.TreeTableModel;
 import com.intellij.util.ui.ColumnInfo;
 import edu.kit.kastel.sdq.artemis4j.client.AnnotationSource;
 import edu.kit.kastel.sdq.artemis4j.grading.Annotation;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 public abstract class AnnotationsTreeNode extends DefaultMutableTreeNode {
     private static final Locale LOCALE = DynamicBundle.getLocale();
@@ -57,7 +57,7 @@ public abstract class AnnotationsTreeNode extends DefaultMutableTreeNode {
         }
 
         @Override
-        public @NotNull PresentationData getPresentation() {
+        public @NonNull PresentationData getPresentation() {
             this.data.clear();
 
             var attributes = NORMAL_ATTRIBUTES;
@@ -220,15 +220,15 @@ public abstract class AnnotationsTreeNode extends DefaultMutableTreeNode {
     public static class AnnotationNode extends AnnotationsTreeNode {
         // This is transient to make sonar happy, because the parent class is serializable.
         // It should never be serialized, so this solution is fine.
-        private final transient @NotNull Annotation annotation;
+        private final transient @NonNull Annotation annotation;
 
-        public AnnotationNode(@NotNull Annotation annotation) {
+        public AnnotationNode(@NonNull Annotation annotation) {
             super(false);
 
             this.annotation = annotation;
         }
 
-        public @NotNull Annotation getAnnotation() {
+        public @NonNull Annotation getAnnotation() {
             return annotation;
         }
 

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/guis/table/AnnotationsTreeTable.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/guis/table/AnnotationsTreeTable.java
@@ -35,7 +35,7 @@ import com.intellij.ui.treeStructure.treetable.TreeTableModel;
 import edu.kit.kastel.sdq.artemis4j.grading.Annotation;
 import edu.kit.kastel.sdq.intelligrade.state.PluginState;
 import edu.kit.kastel.sdq.intelligrade.utils.IntellijUtil;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 public class AnnotationsTreeTable extends TreeTable {
     private static final Logger LOG = Logger.getInstance(AnnotationsTreeTable.class);
@@ -163,7 +163,7 @@ public class AnnotationsTreeTable extends TreeTable {
     private void installDoubleClickListener() {
         new DoubleClickListener() {
             @Override
-            protected boolean onDoubleClick(@NotNull MouseEvent event) {
+            protected boolean onDoubleClick(@NonNull MouseEvent event) {
                 TreePath path = getTree().getLeadSelectionPath();
                 if (path == null) {
                     return true;

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/guis/table/DefaultColumnInfo.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/guis/table/DefaultColumnInfo.java
@@ -2,7 +2,7 @@
 package edu.kit.kastel.sdq.intelligrade.extensions.guis.table;
 
 import com.intellij.util.ui.ColumnInfo;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 class DefaultColumnInfo extends ColumnInfo {
     private final Class<?> columnClass;

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/guis/table/LineLocation.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/guis/table/LineLocation.java
@@ -4,7 +4,7 @@ package edu.kit.kastel.sdq.intelligrade.extensions.guis.table;
 import java.util.Comparator;
 
 import edu.kit.kastel.sdq.artemis4j.grading.Annotation;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 public record LineLocation(int startLine, int endLine) implements Comparable<LineLocation> {
     public static LineLocation fromAnnotation(Annotation annotation) {
@@ -17,7 +17,7 @@ public record LineLocation(int startLine, int endLine) implements Comparable<Lin
     }
 
     @Override
-    public int compareTo(@NotNull LineLocation other) {
+    public int compareTo(@NonNull LineLocation other) {
         return Comparator.comparing(LineLocation::startLine)
                 .thenComparing(LineLocation::endLine)
                 .compare(this, other);

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/guis/table/Lines.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/guis/table/Lines.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import edu.kit.kastel.sdq.artemis4j.grading.Annotation;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 public record Lines(List<LineLocation> locations) implements Comparable<Lines> {
     public static Lines fromLines(List<Lines> lines) {
@@ -22,7 +22,7 @@ public record Lines(List<LineLocation> locations) implements Comparable<Lines> {
     }
 
     @Override
-    public int compareTo(@NotNull Lines other) {
+    public int compareTo(@NonNull Lines other) {
         var left = locations.stream().sorted().toList();
         var right = other.locations.stream().sorted().toList();
 

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/settings/ArtemisSettings.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/settings/ArtemisSettings.java
@@ -22,7 +22,7 @@ import com.intellij.ui.components.JBRadioButton;
 import com.intellij.ui.components.JBTextField;
 import edu.kit.kastel.sdq.intelligrade.state.PluginState;
 import net.miginfocom.swing.MigLayout;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * This class implements the settings Dialog for this PlugIn.

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/settings/ArtemisSettingsState.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/settings/ArtemisSettingsState.java
@@ -12,8 +12,8 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.util.xmlb.XmlSerializer;
 import com.intellij.util.xmlb.XmlSerializerUtil;
 import com.intellij.util.xmlb.annotations.OptionTag;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /**
  * This class persists all required data for the PlugIn.
@@ -86,7 +86,7 @@ public class ArtemisSettingsState implements PersistentStateComponent<ArtemisSet
      * @see XmlSerializerUtil#copyBean(Object, Object)
      */
     @Override
-    public void loadState(@NotNull InternalState state) {
+    public void loadState(@NonNull InternalState state) {
         XmlSerializerUtil.copyBean(state, this.state);
 
         // The annotation color type was changed from an int to a ThemeColor.

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/settings/ThemeColor.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/settings/ThemeColor.java
@@ -7,7 +7,7 @@ import java.util.Objects;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.ui.JBColor;
 import com.intellij.util.xmlb.Converter;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 /**
  * This class represents a color in a format that is supported by the plugin.
@@ -89,7 +89,7 @@ public class ThemeColor {
         private static final int NUMBER_OF_FIELDS = 2;
 
         @Override
-        public ThemeColor fromString(@NotNull String value) {
+        public ThemeColor fromString(@NonNull String value) {
             String[] serializedValues = value.split(SERIALIZED_DELIMITER, -1);
 
             // In previous versions colors were stored as a single int color.
@@ -111,12 +111,12 @@ public class ThemeColor {
             return new ThemeColor(regularColor, darkColor);
         }
 
-        private static @NotNull Color parseColor(String string) {
+        private static @NonNull Color parseColor(String string) {
             return new Color(Integer.parseInt(string), true);
         }
 
         @Override
-        public String toString(@NotNull ThemeColor color) {
+        public String toString(@NonNull ThemeColor color) {
             String[] serializedValues = new String[NUMBER_OF_FIELDS];
 
             serializedValues[REGULAR_COLOR_INDEX] = String.valueOf(color.brightColor.getRGB());

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/tool_windows/AnnotationsToolWindowFactory.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/tool_windows/AnnotationsToolWindowFactory.java
@@ -1,4 +1,4 @@
-/* Licensed under EPL-2.0 2024. */
+/* Licensed under EPL-2.0 2024-2025. */
 package edu.kit.kastel.sdq.intelligrade.extensions.tool_windows;
 
 import com.intellij.openapi.project.Project;
@@ -6,7 +6,7 @@ import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowFactory;
 import com.intellij.ui.content.ContentFactory;
 import edu.kit.kastel.sdq.intelligrade.extensions.guis.AnnotationsListPanel;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 /**
  * This class generates the tool Window for annotations in the bottom.
@@ -14,7 +14,7 @@ import org.jetbrains.annotations.NotNull;
 public class AnnotationsToolWindowFactory implements ToolWindowFactory {
 
     @Override
-    public void createToolWindowContent(@NotNull Project project, @NotNull ToolWindow toolWindow) {
+    public void createToolWindowContent(@NonNull Project project, @NonNull ToolWindow toolWindow) {
         var content = ContentFactory.getInstance().createContent(new AnnotationsListPanel(), null, false);
         toolWindow.show();
         toolWindow.getContentManager().addContent(content);

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/tool_windows/MainToolWindowFactory.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/extensions/tool_windows/MainToolWindowFactory.java
@@ -1,4 +1,4 @@
-/* Licensed under EPL-2.0 2024. */
+/* Licensed under EPL-2.0 2024-2025. */
 package edu.kit.kastel.sdq.intelligrade.extensions.tool_windows;
 
 import com.intellij.openapi.project.DumbAware;
@@ -9,7 +9,7 @@ import com.intellij.ui.content.ContentFactory;
 import edu.kit.kastel.sdq.intelligrade.extensions.guis.AssessmentPanel;
 import edu.kit.kastel.sdq.intelligrade.extensions.guis.ExercisePanel;
 import edu.kit.kastel.sdq.intelligrade.extensions.guis.TestCasePanel;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 /**
  * This class handles all logic for the main grading UI.
@@ -17,7 +17,7 @@ import org.jetbrains.annotations.NotNull;
  */
 public class MainToolWindowFactory implements ToolWindowFactory, DumbAware {
     @Override
-    public void createToolWindowContent(@NotNull Project project, @NotNull ToolWindow toolWindow) {
+    public void createToolWindowContent(@NonNull Project project, @NonNull ToolWindow toolWindow) {
         toolWindow
                 .getContentManager()
                 .addContent(ContentFactory.getInstance().createContent(new ExercisePanel(), "Exercise", false));

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/highlighter/HighlighterManager.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/highlighter/HighlighterManager.java
@@ -38,7 +38,7 @@ import edu.kit.kastel.sdq.intelligrade.extensions.settings.ArtemisSettingsState;
 import edu.kit.kastel.sdq.intelligrade.icons.ArtemisIcons;
 import edu.kit.kastel.sdq.intelligrade.state.PluginState;
 import edu.kit.kastel.sdq.intelligrade.utils.IntellijUtil;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 /**
  * This class manages the highlights (the colored lines that indicate an annotation) in the editor.
@@ -54,7 +54,7 @@ public class HighlighterManager {
         var messageBus = IntellijUtil.getActiveProject().getMessageBus();
         messageBus.connect().subscribe(FileEditorManagerListener.FILE_EDITOR_MANAGER, new FileEditorManagerListener() {
             @Override
-            public void fileOpened(@NotNull FileEditorManager source, @NotNull VirtualFile file) {
+            public void fileOpened(@NonNull FileEditorManager source, @NonNull VirtualFile file) {
                 var editor = source.getSelectedTextEditor();
 
                 if (PluginState.getInstance().isAssessing() && editor != null) {
@@ -64,7 +64,7 @@ public class HighlighterManager {
             }
 
             @Override
-            public void fileClosed(@NotNull FileEditorManager source, @NotNull VirtualFile file) {
+            public void fileClosed(@NonNull FileEditorManager source, @NonNull VirtualFile file) {
                 var editor = source.getSelectedTextEditor();
                 if (editor == null) {
                     return;
@@ -217,7 +217,7 @@ public class HighlighterManager {
             }
 
             @Override
-            public @NotNull Icon getIcon() {
+            public @NonNull Icon getIcon() {
                 return switch (annotations.size()) {
                     case 1 -> ArtemisIcons.AnnotationsGutter1;
                     case 2 -> ArtemisIcons.AnnotationsGutter2;
@@ -313,7 +313,7 @@ public class HighlighterManager {
 
             group.addAction(new AnActionButton(text) {
                 @Override
-                public void actionPerformed(@NotNull AnActionEvent anActionEvent) {
+                public void actionPerformed(@NonNull AnActionEvent anActionEvent) {
                     AnnotationsListPanel.getPanel().selectAnnotation(annotation);
                 }
 
@@ -323,7 +323,7 @@ public class HighlighterManager {
                 }
 
                 @Override
-                public @NotNull ActionUpdateThread getActionUpdateThread() {
+                public @NonNull ActionUpdateThread getActionUpdateThread() {
                     return ActionUpdateThread.EDT;
                 }
             });

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/listeners/OnMouseInEditorMoved.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/listeners/OnMouseInEditorMoved.java
@@ -1,14 +1,14 @@
-/* Licensed under EPL-2.0 2024. */
+/* Licensed under EPL-2.0 2024-2025. */
 package edu.kit.kastel.sdq.intelligrade.listeners;
 
 import com.intellij.openapi.editor.event.EditorMouseEvent;
 import com.intellij.openapi.editor.event.EditorMouseMotionListener;
 import edu.kit.kastel.sdq.intelligrade.highlighter.HighlighterManager;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 public class OnMouseInEditorMoved implements EditorMouseMotionListener {
     @Override
-    public void mouseMoved(@NotNull EditorMouseEvent e) {
+    public void mouseMoved(@NonNull EditorMouseEvent e) {
         HighlighterManager.onMouseMovedInEditor(e);
     }
 }

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/listeners/OnPlugInLoad.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/listeners/OnPlugInLoad.java
@@ -1,4 +1,4 @@
-/* Licensed under EPL-2.0 2024. */
+/* Licensed under EPL-2.0 2024-2025. */
 package edu.kit.kastel.sdq.intelligrade.listeners;
 
 import java.util.List;
@@ -6,7 +6,7 @@ import java.util.List;
 import com.intellij.ide.AppLifecycleListener;
 import edu.kit.kastel.sdq.intelligrade.extensions.settings.ArtemisCredentialsProvider;
 import edu.kit.kastel.sdq.intelligrade.state.PluginState;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Class that handles the events called if the PlugIn is loaded
@@ -15,7 +15,7 @@ import org.jetbrains.annotations.NotNull;
 public class OnPlugInLoad implements AppLifecycleListener {
 
     @Override
-    public void appFrameCreated(@NotNull List<String> commandLineArgs) {
+    public void appFrameCreated(@NonNull List<String> commandLineArgs) {
         AppLifecycleListener.super.appFrameCreated(commandLineArgs);
         ArtemisCredentialsProvider.getInstance().initialize();
         PluginState.getInstance().connect();

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/listeners/OnStartupCompleted.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/listeners/OnStartupCompleted.java
@@ -1,4 +1,4 @@
-/* Licensed under EPL-2.0 2024. */
+/* Licensed under EPL-2.0 2024-2025. */
 package edu.kit.kastel.sdq.intelligrade.listeners;
 
 import com.intellij.openapi.application.ApplicationManager;
@@ -10,13 +10,13 @@ import com.intellij.openapi.wm.ToolWindowManager;
 import edu.kit.kastel.sdq.intelligrade.highlighter.HighlighterManager;
 import kotlin.Unit;
 import kotlin.coroutines.Continuation;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 public class OnStartupCompleted implements ProjectActivity, DumbAware {
     @Nullable
     @Override
-    public Object execute(@NotNull Project project, @NotNull Continuation<? super Unit> continuation) {
+    public Object execute(@NonNull Project project, @NonNull Continuation<? super Unit> continuation) {
         HighlighterManager.initialize();
 
         project.getMessageBus().connect().subscribe(DumbService.DUMB_MODE, FileOpener.getInstance());

--- a/src/main/java/edu/kit/kastel/sdq/intelligrade/login/CefDialog.java
+++ b/src/main/java/edu/kit/kastel/sdq/intelligrade/login/CefDialog.java
@@ -1,4 +1,4 @@
-/* Licensed under EPL-2.0 2024. */
+/* Licensed under EPL-2.0 2024-2025. */
 package edu.kit.kastel.sdq.intelligrade.login;
 
 import java.awt.GridLayout;
@@ -10,8 +10,8 @@ import javax.swing.JPanel;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.DialogWrapper;
 import com.intellij.ui.jcef.JBCefBrowser;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 public class CefDialog extends DialogWrapper {
     private final JBCefBrowser browser;
@@ -33,7 +33,7 @@ public class CefDialog extends DialogWrapper {
     }
 
     @Override
-    protected Action @NotNull [] createActions() {
+    protected Action @NonNull [] createActions() {
         return new Action[0];
     }
 }


### PR DESCRIPTION
This pull request updates the codebase to use `@NonNull` and `@Nullable` annotations from the `org.jspecify.annotations` package instead of the previous `org.jetbrains.annotations` equivalents. This affects method signatures, fields, and parameters throughout the project, improving consistency and aligning with the newer annotation standard. 

**Migration to jspecify nullness annotations:**

* Replaced all usages of `@NotNull` and `@Nullable` from `org.jetbrains.annotations` with `@NonNull` and `@Nullable` from `org.jspecify.annotations` across the codebase, including method signatures, parameters, and fields in files 

Fixes #164 